### PR TITLE
Fix front page spacing, colors, and layout

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -7,7 +7,7 @@ export default function Home() {
   return (
     <>
       <Navbar />
-      <main className="pt-[200px]">
+      <main className="pt-[160px]">
         <ImageStrip />
         <ManifestoSection />
       </main>

--- a/components/FooterBanner.tsx
+++ b/components/FooterBanner.tsx
@@ -49,14 +49,14 @@ export default function FooterBanner({ showAddress = false, showMarquee = true }
                 href="https://maps.app.goo.gl/f3nJEyLJXxKStLvPA"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="block font-[400] uppercase text-coral hover:opacity-70 transition-opacity w-full"
+                className="block font-[400] uppercase text-dark hover:opacity-70 transition-opacity w-full"
                 style={{ fontSize: 'clamp(28px, 3.5vw, 45px)', textAlign: 'justify', textAlignLast: 'justify' } as React.CSSProperties}
               >
                 {t('address')}
               </a>
               <a
                 href="mailto:hello@koolstudio.pl"
-                className="block font-[700] uppercase text-coral hover:opacity-70 transition-opacity w-full"
+                className="block font-[700] uppercase text-dark hover:opacity-70 transition-opacity w-full"
                 style={{ fontSize: 'clamp(32px, 4.2vw, 55px)' }}
               >
                 {t('email')}

--- a/components/ImageStrip.tsx
+++ b/components/ImageStrip.tsx
@@ -36,7 +36,7 @@ export default function ImageStrip() {
   }, [next]);
 
   return (
-    <div className="relative w-full min-h-[calc(100svh-200px)] flex items-start">
+    <div className="relative w-full min-h-[calc(100svh-160px)] flex items-start">
       {/* Desktop: 3-column grid */}
       <div className="hidden md:grid w-full grid-cols-3 gap-[3px]">
         {[0, 1, 2].map((col) => (
@@ -90,7 +90,7 @@ export default function ImageStrip() {
       {/* Scroll indicator — three animated dots */}
       <motion.div
         style={{ opacity: indicatorOpacity }}
-        className="absolute bottom-12 left-1/2 -translate-x-1/2 flex flex-col items-center gap-2"
+        className="absolute bottom-6 left-1/2 -translate-x-1/2 flex flex-col items-center gap-2"
       >
         {[0, 1, 2].map((i) => (
           <motion.div

--- a/components/ManifestoSection.tsx
+++ b/components/ManifestoSection.tsx
@@ -10,7 +10,7 @@ export default function ManifestoSection() {
   return (
     <>
       {/* Section 1: text left, tilted image right */}
-      <section className="mt-[100px] md:mt-[140px]">
+      <section className="mt-[60px] md:mt-[80px]">
         <div className="max-w-[1400px] mx-auto px-5 md:px-10 lg:px-12">
           <div className="flex flex-col md:flex-row gap-12 md:gap-16 items-start">
             <div className="md:w-[50%]">
@@ -26,7 +26,7 @@ export default function ManifestoSection() {
             </div>
 
             <div className="md:w-[45%] md:ml-auto flex justify-end">
-              <div className="relative w-[80%] md:w-full aspect-[3/4] rotate-[6deg] overflow-hidden">
+              <div className="relative w-[80%] md:w-full aspect-[3/4] overflow-hidden">
                 <Image
                   src="/images/oferta/residential-04.jpg"
                   alt="Material moodboard"


### PR DESCRIPTION
## Summary
- Remove tilted rotation from moodboard image
- Footer address/email color: coral → dark
- Reduce logo-to-images gap (pt-[200px] → pt-[160px])
- Reduce section-to-section gap
- Move scroll indicator dots closer to bottom
- Sync ImageStrip min-h with new padding

## Test plan
- [ ] Visit `/pl` — verify moodboard image is straight
- [ ] Verify footer address/email is dark, not coral
- [ ] Compare logo-to-images spacing with production
- [ ] Scroll dots visible near bottom of image strip

🤖 Generated with [Claude Code](https://claude.com/claude-code)