### PR TITLE
Oferta: ColumnImage primitive, smaller scope images, left-aligned logos

### DIFF
--- a/components/ColumnImage.tsx
+++ b/components/ColumnImage.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import Image from 'next/image';
+
+type Fit = 'cover' | 'contain';
+type Align = 'start' | 'center' | 'end';
+
+interface ColumnImageProps {
+  src: string;
+  alt: string;
+  /** Portrait aspect-ratio utility for the frame (default "aspect-[2/3]"). */
+  aspect?: string;
+  /** Frame width within its column — smaller = more breathing room (default "w-[70%] md:w-[58%]"). */
+  width?: string;
+  /** How the image fills its frame (default "cover"). */
+  fit?: Fit;
+  /** Horizontal placement of the frame inside the column (default "center"). */
+  align?: Align;
+  /** Vertical placement of the frame inside the column (default "start"). */
+  valign?: 'start' | 'center';
+  /** Extra classes on the column wrapper (e.g. "md:w-1/2", breathing-room padding). */
+  className?: string;
+  /** next/image sizes hint (default "(min-width: 768px) 30vw, 70vw"). */
+  sizes?: string;
+  priority?: boolean;
+}
+
+const JUSTIFY: Record<Align, string> = {
+  start: 'justify-start',
+  center: 'justify-center',
+  end: 'justify-end',
+};
+
+/**
+ * A portrait image sized to sit inside a (typically half-width) column with
+ * breathing room, rather than filling the whole slot. Extracted from the
+ * project-page "small" image pattern so any page can reuse the same treatment.
+ */
+export default function ColumnImage({
+  src,
+  alt,
+  aspect = 'aspect-[2/3]',
+  width = 'w-[70%] md:w-[58%]',
+  fit = 'cover',
+  align = 'center',
+  valign = 'start',
+  className = '',
+  sizes = '(min-width: 768px) 30vw, 70vw',
+  priority,
+}: ColumnImageProps) {
+  return (
+    <div className={`flex ${JUSTIFY[align]} ${valign === 'center' ? 'items-center' : 'items-start'} ${className}`}>
+      <div className={`relative ${width} ${aspect} overflow-hidden`}>
+        <Image
+          src={src}
+          alt={alt}
+          fill
+          className={fit === 'contain' ? 'object-contain' : 'object-cover'}
+          sizes={sizes}
+          priority={priority}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/ProjectContent.tsx
+++ b/components/ProjectContent.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 import BeforeAfterSlider from './BeforeAfterSlider';
+import ColumnImage from './ColumnImage';
 
 type SliderData = { beforeSrc: string; afterSrc: string; labels?: [string, string] };
 type Item =
@@ -31,11 +32,15 @@ interface ProjectContentProps {
 function PaddedImage({ src, small }: { src: string; small?: boolean }) {
   if (small) {
     return (
-      <div className="w-full md:w-1/2 p-6 md:p-10 lg:p-14 xl:p-20 flex items-start justify-center">
-        <div className="relative w-[72%] md:w-[60%] aspect-[9/16]">
-          <Image src={src} alt="Kool Studio project" fill className="object-contain" sizes="(max-width: 768px) 72vw, 30vw" />
-        </div>
-      </div>
+      <ColumnImage
+        src={src}
+        alt="Kool Studio project"
+        aspect="aspect-[9/16]"
+        width="w-[72%] md:w-[60%]"
+        fit="contain"
+        className="w-full md:w-1/2 p-6 md:p-10 lg:p-14 xl:p-20"
+        sizes="(max-width: 768px) 72vw, 30vw"
+      />
     );
   }
   return (

--- a/components/oferta/ProcessSection.tsx
+++ b/components/oferta/ProcessSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import Image from 'next/image';
+import ColumnImage from '@/components/ColumnImage';
 
 interface ProcessSectionProps {
   label: string;
@@ -52,17 +52,13 @@ export default function ProcessSection({
           transition={{ duration: 0.6, delay: 0.2 }}
           className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-0 mb-16 md:mb-24 items-stretch"
         >
-          <div className="flex justify-center md:pr-8 lg:pr-12">
-            <div className="relative w-[78%] md:w-[72%] aspect-[2/3] overflow-hidden">
-              <Image
-                src={imageSrc}
-                alt={imageAlt}
-                fill
-                className="object-cover"
-                sizes="(min-width: 768px) 34vw, 78vw"
-              />
-            </div>
-          </div>
+          <ColumnImage
+            src={imageSrc}
+            alt={imageAlt}
+            width="w-[74%] md:w-[64%]"
+            className="md:pr-8 lg:pr-12"
+            sizes="(min-width: 768px) 32vw, 74vw"
+          />
 
           <div className="flex flex-col justify-center md:pl-8 lg:pl-12">
             <ol className="space-y-6 md:space-y-9">

--- a/components/oferta/ServiceSection.tsx
+++ b/components/oferta/ServiceSection.tsx
@@ -3,6 +3,7 @@
 import { motion, AnimatePresence } from 'framer-motion';
 import Image from 'next/image';
 import { Link } from '@/i18n/navigation';
+import ColumnImage from '@/components/ColumnImage';
 
 const easeOutExpo: [number, number, number, number] = [0.22, 1, 0.36, 1];
 
@@ -96,17 +97,13 @@ export default function ServiceSection({
               {/* Scope: image + list — split 50/50 down the page middle */}
               <div className="mt-12 md:mt-16 grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-0 items-start">
                 {scopeImageSrc && (
-                  <div className="flex justify-center md:pr-8 lg:pr-12">
-                    <div className="relative w-[78%] md:w-[72%] aspect-[2/3] overflow-hidden">
-                      <Image
-                        src={scopeImageSrc}
-                        alt={scopeImageAlt}
-                        fill
-                        className="object-cover"
-                        sizes="(min-width: 768px) 34vw, 78vw"
-                      />
-                    </div>
-                  </div>
+                  <ColumnImage
+                    src={scopeImageSrc}
+                    alt={scopeImageAlt}
+                    width="w-[68%] md:w-[56%]"
+                    className="md:pr-8 lg:pr-12 md:pt-14 lg:pt-24"
+                    sizes="(min-width: 768px) 28vw, 68vw"
+                  />
                 )}
                 <div className={scopeImageSrc ? 'md:pl-8 lg:pl-12' : 'col-span-full'}>
                   <h3
@@ -147,12 +144,12 @@ export default function ServiceSection({
                 {trustedByLabel && trustedByLogos && (
                   <div className="mt-12 md:mt-16">
                     <span
-                      className="font-[400] uppercase text-dark/60 mb-8 block text-center"
+                      className="font-[400] uppercase text-dark/60 mb-8 block"
                       style={{ fontSize: 'clamp(13px, 1.3vw, 18px)' }}
                     >
                       {trustedByLabel}
                     </span>
-                    <div className="flex items-center justify-center gap-x-12 md:gap-x-20 gap-y-8 flex-wrap">
+                    <div className="flex items-center justify-start gap-x-12 md:gap-x-20 gap-y-8 flex-wrap">
                       {trustedByLogos.map((logo, i) => (
                         <Image
                           key={i}


### PR DESCRIPTION
## Summary
Follow-up refinements to the offer page plus a reusable image primitive.

- **`ColumnImage` primitive** (`components/ColumnImage.tsx`) — a portrait image sized to sit inside a (typically half-width) column with breathing room, parameterized (aspect, width, fit, align, valign, padding, sizes). Extracted from the project-page "small" image pattern and adopted in both oferta scope sections, the process section, and the project-page aksonometria image, so new pages can reuse the treatment.
- **Scope images** — smaller (`md:w-[56%]`) and dropped below the "ZAKRES WSPÓŁPRACY:" list header via top padding, so the image starts around the header/first bullet and spans the list height.
- **Process image** — slightly smaller via the primitive.
- **Logos** — "Zaufali nam" label and the client-logo row now left-aligned (start from the left).

## Verification
`pnpm check` (typecheck + lint + i18n parity + build) passes. Verified in-browser: commercial/residential scope balance, left-aligned logos, process section, and the project-page aksonometria (unchanged through the primitive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)