### PR TITLE
Navbar: fix choppy mobile logo shrink on scroll

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useSyncExternalStore } from 'react';
-import { AnimatePresence, motion, useScroll, useTransform } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 import { Link, usePathname } from '@/i18n/navigation';
@@ -44,10 +44,22 @@ export default function Navbar() {
     return () => { document.body.style.overflow = ''; };
   }, [menuOpen, isMobile]);
 
-  const { scrollY } = useScroll();
-  const logoScale = useTransform(scrollY, [0, 200], [1, 0.45]);
-  const dotScale = useTransform(scrollY, [0, 200], isMobile ? [1, 0.7] : [1, 1]);
-  const dotY = useTransform(scrollY, [0, 200], isMobile ? [0, -16] : [0, 0]);
+  // Threshold toggle + CSS transition instead of a scroll-linked motion value:
+  // JS-driven transforms jank in Mobile Safari during touch scroll, while a
+  // one-shot CSS transform transition runs on the compositor. Hysteresis
+  // (80/20) prevents flicker at the boundary and during rubber-banding.
+  const [shrunk, setShrunk] = useState(false);
+  useEffect(() => {
+    const onScroll = () => {
+      const y = window.scrollY;
+      setShrunk((prev) => (prev ? y > 20 : y > 80));
+    };
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const shrinkTransition = 'transition-transform duration-500 ease-[cubic-bezier(0.22,1,0.36,1)]';
 
   const isActive = (href: string) => {
     if (href === '/') return pathname === '/';
@@ -63,15 +75,14 @@ export default function Navbar() {
             <span className="hidden md:block">
               <Image src="/logo.svg" alt="Kool Studio" width={208} height={77} priority />
             </span>
-            {/* Mobile: shrink on scroll + burn blend */}
-            <motion.span
-              className="block md:hidden origin-top-left"
-              style={{
-                scale: logoScale,
-              }}
+            {/* Mobile: shrink past the scroll threshold, grow back near the top */}
+            <span
+              className={`block md:hidden origin-top-left will-change-transform ${shrinkTransition} ${
+                shrunk ? 'scale-[0.45]' : 'scale-100'
+              }`}
             >
               <Image src="/logo.svg" alt="Kool Studio" width={208} height={77} priority />
-            </motion.span>
+            </span>
           </Link>
 
           <div className="flex items-center gap-10">
@@ -116,10 +127,11 @@ export default function Navbar() {
             </AnimatePresence>
 
             {/* The single dot — always visible, toggles menu */}
-            <motion.button
+            <button
               onClick={() => setMenuOpen(!menuOpen)}
-              className="w-[36px] h-[35px] hover:opacity-80 transition-opacity shrink-0 origin-top-right"
-              style={{ scale: dotScale, y: dotY }}
+              className={`w-[36px] h-[35px] hover:opacity-80 shrink-0 origin-top-right will-change-transform ${shrinkTransition} ${
+                shrunk ? 'max-md:scale-[0.7] max-md:-translate-y-4' : ''
+              }`}
               aria-label={menuOpen ? 'Close menu' : 'Open menu'}
             >
               <motion.div
@@ -138,7 +150,7 @@ export default function Navbar() {
               >
                 <Image src="/dot.svg" alt="" width={36} height={35} />
               </motion.div>
-            </motion.button>
+            </button>
           </div>
         </div>
       </nav>
@@ -168,23 +180,28 @@ export default function Navbar() {
             className="fixed inset-0 z-[100] bg-coral flex flex-col md:hidden"
           >
             <div className="w-full px-4 pt-4 pb-6 flex items-center justify-between">
-              <motion.span className="origin-top-left" style={{ scale: logoScale }}>
+              <span
+                className={`origin-top-left will-change-transform ${shrinkTransition} ${
+                  shrunk ? 'scale-[0.45]' : 'scale-100'
+                }`}
+              >
                 <div
                   className="w-[208px] h-[77px] bg-beige"
                   style={{ maskImage: 'url(/logo.svg)', maskSize: 'contain', maskRepeat: 'no-repeat' }}
                 />
-              </motion.span>
-              <motion.button
+              </span>
+              <button
                 onClick={() => setMenuOpen(false)}
-                className="w-[36px] h-[35px] hover:opacity-80 transition-opacity shrink-0 origin-top-right"
-                style={{ scale: dotScale, y: dotY }}
+                className={`w-[36px] h-[35px] hover:opacity-80 shrink-0 origin-top-right will-change-transform ${shrinkTransition} ${
+                  shrunk ? 'scale-[0.7] -translate-y-4' : ''
+                }`}
                 aria-label="Close menu"
               >
                 <div
                   className="w-[36px] h-[35px] bg-beige rounded-full"
                   style={{ maskImage: 'url(/dot.svg)', maskSize: 'contain', maskRepeat: 'no-repeat' }}
                 />
-              </motion.button>
+              </button>
             </div>
 
             <nav className="absolute inset-0 flex flex-col items-center justify-center gap-8 text-center pointer-events-none">


### PR DESCRIPTION
## Summary
- The mobile logo shrink-on-scroll was janky in Mobile Safari: the scale was driven by Framer Motion on the JS main thread, which Safari deprioritizes during touch scrolling.
- Replaced the continuous scroll-linked scale with a threshold toggle (shrink past 80px, grow back under 20px — hysteresis prevents flicker at the boundary/rubber-banding) animated by a pure CSS transform transition, which runs on the compositor at full frame rate.
- Applies to the mobile logo, the menu dot, and their counterparts inside the coral menu overlay. Desktop stays fully static, as designed.

## Verification
- `pnpm check` passes (typecheck, lint, i18n parity, build)
- Browser-verified at 1280px (logo/dot static when scrolled) and 390px (logo 208px → 94px through smooth intermediate frames, back to 208px at top; 50px scroll from top correctly does not trigger the shrink); no new console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)