### PR TITLE
Navbar: restore scroll-position-linked logo scale (compositor-driven)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -34,3 +34,47 @@ body {
 .animate-marquee-diagonal {
   animation: marquee 15s linear infinite;
 }
+
+/* Mobile navbar: logo/dot scale tracks scroll position (0-200px).
+   Where CSS scroll timelines are supported (Safari 26+, Chrome 115+) the
+   animation runs on the compositor, immune to main-thread jank during touch
+   scrolling, and overrides the inline Framer Motion transform. Elsewhere the
+   spring-smoothed Framer values in Navbar.tsx keep driving the transform. */
+@media (width < 768px) {
+  @supports (animation-timeline: scroll()) {
+    .nav-logo-shrink,
+    .nav-dot-shrink {
+      animation-duration: auto;
+      animation-timing-function: linear;
+      animation-fill-mode: both;
+      animation-timeline: scroll(root);
+      animation-range: 0px 200px;
+    }
+    .nav-logo-shrink {
+      animation-name: nav-logo-shrink;
+    }
+    .nav-dot-shrink {
+      animation-name: nav-dot-shrink;
+    }
+  }
+}
+
+/* Explicit from-keyframes so the animation replaces the inline Framer
+   transform instead of compositing with it */
+@keyframes nav-logo-shrink {
+  from {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(0.45);
+  }
+}
+
+@keyframes nav-dot-shrink {
+  from {
+    transform: translateY(0) scale(1);
+  }
+  to {
+    transform: translateY(-16px) scale(0.7);
+  }
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useSyncExternalStore } from 'react';
-import { AnimatePresence, motion } from 'framer-motion';
+import { AnimatePresence, motion, useScroll, useSpring, useTransform } from 'framer-motion';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 import { Link, usePathname } from '@/i18n/navigation';
@@ -44,22 +44,15 @@ export default function Navbar() {
     return () => { document.body.style.overflow = ''; };
   }, [menuOpen, isMobile]);
 
-  // Threshold toggle + CSS transition instead of a scroll-linked motion value:
-  // JS-driven transforms jank in Mobile Safari during touch scroll, while a
-  // one-shot CSS transform transition runs on the compositor. Hysteresis
-  // (80/20) prevents flicker at the boundary and during rubber-banding.
-  const [shrunk, setShrunk] = useState(false);
-  useEffect(() => {
-    const onScroll = () => {
-      const y = window.scrollY;
-      setShrunk((prev) => (prev ? y > 20 : y > 80));
-    };
-    onScroll();
-    window.addEventListener('scroll', onScroll, { passive: true });
-    return () => window.removeEventListener('scroll', onScroll);
-  }, []);
-
-  const shrinkTransition = 'transition-transform duration-500 ease-[cubic-bezier(0.22,1,0.36,1)]';
+  // Scroll-linked shrink: browsers with CSS scroll timelines animate the
+  // .nav-logo-shrink/.nav-dot-shrink classes on the compositor (globals.css),
+  // which overrides these inline values and stays smooth in Mobile Safari.
+  // Older browsers fall back to the spring-smoothed values below.
+  const { scrollY } = useScroll();
+  const smoothScrollY = useSpring(scrollY, { stiffness: 260, damping: 34, restDelta: 0.5 });
+  const logoScale = useTransform(smoothScrollY, [0, 200], [1, 0.45]);
+  const dotScale = useTransform(smoothScrollY, [0, 200], isMobile ? [1, 0.7] : [1, 1]);
+  const dotY = useTransform(smoothScrollY, [0, 200], isMobile ? [0, -16] : [0, 0]);
 
   const isActive = (href: string) => {
     if (href === '/') return pathname === '/';
@@ -75,14 +68,13 @@ export default function Navbar() {
             <span className="hidden md:block">
               <Image src="/logo.svg" alt="Kool Studio" width={208} height={77} priority />
             </span>
-            {/* Mobile: shrink past the scroll threshold, grow back near the top */}
-            <span
-              className={`block md:hidden origin-top-left will-change-transform ${shrinkTransition} ${
-                shrunk ? 'scale-[0.45]' : 'scale-100'
-              }`}
+            {/* Mobile: scale tracks scroll position */}
+            <motion.span
+              className="block md:hidden origin-top-left will-change-transform nav-logo-shrink"
+              style={{ scale: logoScale }}
             >
               <Image src="/logo.svg" alt="Kool Studio" width={208} height={77} priority />
-            </span>
+            </motion.span>
           </Link>
 
           <div className="flex items-center gap-10">
@@ -127,11 +119,10 @@ export default function Navbar() {
             </AnimatePresence>
 
             {/* The single dot — always visible, toggles menu */}
-            <button
+            <motion.button
               onClick={() => setMenuOpen(!menuOpen)}
-              className={`w-[36px] h-[35px] hover:opacity-80 shrink-0 origin-top-right will-change-transform ${shrinkTransition} ${
-                shrunk ? 'max-md:scale-[0.7] max-md:-translate-y-4' : ''
-              }`}
+              className="w-[36px] h-[35px] hover:opacity-80 shrink-0 origin-top-right will-change-transform nav-dot-shrink"
+              style={{ scale: dotScale, y: dotY }}
               aria-label={menuOpen ? 'Close menu' : 'Open menu'}
             >
               <motion.div
@@ -150,7 +141,7 @@ export default function Navbar() {
               >
                 <Image src="/dot.svg" alt="" width={36} height={35} />
               </motion.div>
-            </button>
+            </motion.button>
           </div>
         </div>
       </nav>
@@ -180,28 +171,26 @@ export default function Navbar() {
             className="fixed inset-0 z-[100] bg-coral flex flex-col md:hidden"
           >
             <div className="w-full px-4 pt-4 pb-6 flex items-center justify-between">
-              <span
-                className={`origin-top-left will-change-transform ${shrinkTransition} ${
-                  shrunk ? 'scale-[0.45]' : 'scale-100'
-                }`}
+              <motion.span
+                className="origin-top-left will-change-transform nav-logo-shrink"
+                style={{ scale: logoScale }}
               >
                 <div
                   className="w-[208px] h-[77px] bg-beige"
                   style={{ maskImage: 'url(/logo.svg)', maskSize: 'contain', maskRepeat: 'no-repeat' }}
                 />
-              </span>
-              <button
+              </motion.span>
+              <motion.button
                 onClick={() => setMenuOpen(false)}
-                className={`w-[36px] h-[35px] hover:opacity-80 shrink-0 origin-top-right will-change-transform ${shrinkTransition} ${
-                  shrunk ? 'scale-[0.7] -translate-y-4' : ''
-                }`}
+                className="w-[36px] h-[35px] hover:opacity-80 shrink-0 origin-top-right will-change-transform nav-dot-shrink"
+                style={{ scale: dotScale, y: dotY }}
                 aria-label="Close menu"
               >
                 <div
                   className="w-[36px] h-[35px] bg-beige rounded-full"
                   style={{ maskImage: 'url(/dot.svg)', maskSize: 'contain', maskRepeat: 'no-repeat' }}
                 />
-              </button>
+              </motion.button>
             </div>
 
             <nav className="absolute inset-0 flex flex-col items-center justify-center gap-8 text-center pointer-events-none">


### PR DESCRIPTION
## Summary
- The threshold-toggle approach from #14 fixed the Mobile Safari jank but lost the progressive feel — logo size no longer tracked scroll position.
- This restores the scroll-linked mapping (scale 1 → 0.45 over the first 200px) using a CSS scroll-driven animation (`animation-timeline: scroll(root)`), which runs on the compositor and stays smooth during touch scrolling. Supported in Safari 26+ / iOS 26+ and Chrome 115+.
- Browsers without scroll-timeline support fall back to the spring-smoothed Framer Motion values (the pre-#14 behavior); where the CSS animation is supported it overrides the inline Framer transform via explicit from/to keyframes.
- Applies to the mobile logo, menu dot, and their coral-overlay counterparts. Desktop remains static.

## Verification
- `pnpm check` passes (typecheck, lint, i18n parity, build)
- Browser-verified at 390px: logo width tracks scroll position exactly linearly (25px → 193.7, 50 → 179.4, 100 → 150.8, 150 → 122.2, 200+ → 93.6, back to 208 at top), dot shrinks/rises in sync; desktop logo and dot fully static; no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)