### PR TITLE
Restyle project card caption to preview-style two-line layout

### DIFF
--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -24,17 +24,6 @@ export default function ProjectCard({ project }: ProjectCardProps) {
               className="object-cover transition-transform duration-[600ms] group-hover:scale-[1.04]"
               sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
             />
-            {project.status === 'in_progress' && (
-              <div className="absolute left-0 right-0 top-[78%] -translate-y-1/2 overflow-hidden pointer-events-none py-2">
-                <div className="animate-marquee flex gap-8 w-max" style={{ animationDuration: '34s' }}>
-                  {Array.from({ length: 20 }).map((_, i) => (
-                    <span key={i} className="text-coral text-[13px] font-[700] uppercase tracking-[0.15em] shrink-0">
-                      {t('inProgress')}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            )}
           </div>
         </div>
       </Link>

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -24,6 +24,17 @@ export default function ProjectCard({ project }: ProjectCardProps) {
               className="object-cover transition-transform duration-[600ms] group-hover:scale-[1.04]"
               sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
             />
+            {project.status === 'in_progress' && (
+              <div className="absolute left-0 right-0 top-[78%] -translate-y-1/2 overflow-hidden pointer-events-none py-2">
+                <div className="animate-marquee flex gap-8 w-max" style={{ animationDuration: '34s' }}>
+                  {Array.from({ length: 20 }).map((_, i) => (
+                    <span key={i} className="text-coral text-[13px] font-[700] uppercase tracking-[0.15em] shrink-0">
+                      {t('inProgress')}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
         </div>
       </Link>

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -39,9 +39,27 @@ export default function ProjectCard({ project }: ProjectCardProps) {
         </div>
       </Link>
 
-      <p className="mt-2 text-[14px] md:text-[15px] font-[500] text-dark text-center uppercase">
-        {project.title} / {project.location}
-      </p>
+      <div className="mt-3">
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-4">
+          <p className="min-w-0 text-[14px] font-[700] uppercase leading-[1.15] tracking-[-0.02em] text-dark md:text-[15px]">
+            {project.title}
+          </p>
+          <p className="max-w-[12rem] text-right text-[10px] font-[500] uppercase leading-[1.3] tracking-[0.08em] text-muted md:text-[11px]">
+            {project.location}
+          </p>
+        </div>
+        <div className="mt-1.5 flex items-end justify-between gap-4">
+          <p className="text-[10px] font-[500] uppercase leading-none tracking-[0.08em] text-muted md:text-[11px]">
+            {t(project.category)} / {project.year}
+          </p>
+          {project.status === 'in_progress' && (
+            <p className="inline-flex shrink-0 items-center gap-1.5 text-[10px] font-[700] uppercase leading-none tracking-[0.08em] text-coral md:text-[11px]">
+              <span className="size-[6px] rounded-full bg-coral" aria-hidden />
+              {t('inProgress')}
+            </p>
+          )}
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace the centered `TITLE / LOCATION` card caption on the projects listing with the two-line layout from the design preview: bold title + muted location on the first line, muted `CATEGORY / YEAR` + status on the second
- Typography copied from the preview deployment's computed styles (14–15px/700 title with tight tracking; 10–11px/500 letter-spaced muted text)
- Intentional deviations per request: no card border, tighter gap between the two lines, and a coral **dot** (not square) + localized "w trakcie realizacji" / "in progress" label for in-progress projects

## Testing
- `pnpm check` (typecheck, lint, i18n parity, build) passes
- Verified in browser against the preview deployment at identical viewport width — desktop and mobile, both locales' translation keys already existed

🤖 Generated with [Claude Code](https://claude.com/claude-code)