### PR TITLE
SEO & lead-gen playbook implementation: technical SEO, entity graph, service pages, brief form, case studies, analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Kool Studio — environment variables
+# Copy to `.env.local` (gitignored) and fill in to enable a channel.
+# The project-brief form (/kontakt) works WITHOUT any of these: with no
+# RESEND_API_KEY set, the form falls back to opening the visitor's email app
+# with a prefilled message to hello@koolstudio.pl.
+
+# --- Project-brief email delivery (optional) ---------------------------------
+# When RESEND_API_KEY is set, brief submissions are delivered server-side via
+# the Resend HTTP API (https://resend.com). When it is unset, the form uses the
+# mailto fallback described above.
+RESEND_API_KEY=
+
+# Recipient of brief submissions. Defaults to hello@koolstudio.pl when unset.
+BRIEF_TO_EMAIL=
+
+# From address for delivered briefs. Must be a domain verified in Resend.
+# Defaults to onboarding@resend.dev (Resend's shared testing sender) when unset.
+BRIEF_FROM_EMAIL=

--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,14 @@ BRIEF_TO_EMAIL=
 # From address for delivered briefs. Must be a domain verified in Resend.
 # Defaults to onboarding@resend.dev (Resend's shared testing sender) when unset.
 BRIEF_FROM_EMAIL=
+
+# --- Analytics: Google Analytics 4 (optional, currently UNSET) ---------------
+# GA4 measurement id, e.g. G-XXXXXXXXXX. When set, the site loads GA4 (gtag.js)
+# with Consent Mode v2 defaults set to DENIED for every storage signal
+# (ad_storage, ad_user_data, ad_personalization, analytics_storage) BEFORE any
+# config runs. No consent-management platform (CMP) has been chosen yet
+# (decision-log G4), so consent stays DENIED-BY-DEFAULT: GA4 runs in
+# cookieless-ping mode only until a CMP grants analytics_storage via
+# grantAnalyticsConsent() (see lib/analytics.ts). Leave UNSET to ship zero
+# analytics scripts and zero runtime behavior (the default / current state).
+NEXT_PUBLIC_GA4_ID=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # Tests, typecheck, lint, pl/en i18n parity, production build
+      - run: pnpm check

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ next-env.d.ts
 # Agent/tooling artifacts
 .omc/
 .playwright-mcp/
+.context/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,8 @@ pnpm start     # Start production server on $PORT, falling back to 8080
 pnpm lint      # Run ESLint CLI
 pnpm typecheck # Run TypeScript without emitting files
 pnpm check:i18n # Verify pl.json/en.json translation keys match
-pnpm check     # Typecheck, lint, i18n parity, and build
+pnpm test      # Vitest suites + node --test (tests/*.test.ts)
+pnpm check     # Tests, typecheck, lint, i18n parity, and build
 ```
 
 ## Project Structure
@@ -34,19 +35,24 @@ app/
   [locale]/                # All pages nested under locale segment
     layout.tsx             # Root layout, Poppins font, JSON-LD, NextIntlClientProvider
     page.tsx               # Homepage (Navbar, ImageStrip, ManifestoSection, FooterBanner)
-    projekty/              # Projects listing + [slug] detail pages
+    projekty/              # Projects listing + [slug] detail pages (case-study blocks, breadcrumbs)
     studio/                # Studio/about page
-    oferta/                # Services page
-    kontakt/               # Contact page
+    oferta/                # Services hub + [service]/ landing pages (projekt-mieszkania, projekt-domu, wnetrza-komercyjne)
+    kontakt/               # Contact page + project-brief form (actions.ts server action, brief-state.ts)
     design-system/         # Private styleguide (dev-only, 404s in production)
     [...rest]/             # Catch-all route -> notFound()
     not-found.tsx          # Custom 404 page
 components/                # Shared UI components (PascalCase)
-  oferta/                  # Page-scoped components (ServiceSection, ProcessSection)
-data/projects.ts           # Project data + types (Project type)
+  oferta/                  # Page-scoped components (ServiceSection, ProcessSection, ServiceLandingPage, FaqAccordion, ServicesHubLinks)
+  kontakt/                 # BriefForm (client form for the project brief)
+data/projects.ts           # Project data + types (Project type, caseStudy blocks, relatedService)
+data/services.ts           # Service landing-page content (PL canonical + en, localizeService)
 data/press.ts              # Press features (studio page + llms.txt)
 lib/site.ts                # BASE_URL, INSTAGRAM_URL (client-safe constants)
 lib/metadata.ts            # localeAlternates + pageMetadata helpers (server-only)
+lib/schema.ts              # JSON-LD entity graph builders (stable @ids: #organization, #website, Person, WebPage, BreadcrumbList)
+lib/brief.ts               # Brief-form validation/spam/mailto logic (dependency-free, tested)
+lib/analytics.ts           # Env-gated GA4 event helpers (no-PII event dictionary, consent helpers)
 i18n/
   request.ts               # Locale config, getRequestConfig
   navigation.ts            # Typed Link, redirect, usePathname, useRouter
@@ -58,6 +64,8 @@ public/
   videos/                  # Video assets (reel.mp4)
   logo.svg, dot.svg        # Brand assets
 docs/superpowers/          # Design spec + implementation plan (historical records)
+docs/playbook/             # SEO/lead-gen ops docs: decision-log.md (unconfirmed business facts - check before adding claims), NAP sheet, AI-audit prompts, press kits, backlog, analytics-events.md
+tests/                     # node --test suites (brief validation); vitest colocated as components/*.test.ts(x)
 .claude/                   # Agent settings + project skills (verify-site, add-project, build-from-design)
 design/                    # Gitignored inbox for designer PDF/.ai mockups
 scripts/check-i18n.mjs     # pl/en translation key parity check
@@ -148,12 +156,13 @@ Project skills live in `.claude/skills/`; shared agent permissions in `.claude/s
 
 - Next.js 16 App Router: route `params` is a Promise — type as `params: Promise<{...}>` and `await params` (see `app/[locale]/layout.tsx`)
 - There is intentionally no `tailwind.config.*` — Tailwind v4 design tokens live in `@theme` in `app/globals.css`
-- There are no automated tests — `pnpm check` (typecheck + lint + i18n parity + build) is the verification gate before claiming work done
+- `pnpm check` (tests + typecheck + lint + i18n parity + build) is the verification gate before claiming work done; tests are vitest (colocated `components/*.test.ts(x)`) plus `node --test` suites in `tests/`
+- Business facts (prices, hours, phone, SLAs, service claims) must never be added to site copy or JSON-LD unless confirmed — open items live in `docs/playbook/decision-log.md`
 
 ## SEO
 
 - Locale-aware metadata via `generateMetadata` in `app/[locale]/layout.tsx`; each static subpage sets its own title/description/canonical via `pageMetadata()` from `lib/metadata.ts` (strings live in `messages/*.json` under `meta.*` — keep pl/en parity)
-- JSON-LD `ProfessionalService` schema in layout `<head>`; per-project `CreativeWork` + `BreadcrumbList` in `app/[locale]/projekty/[slug]/page.tsx`
+- JSON-LD entity graph from `lib/schema.ts` (stable `@id`s shared across locales): `LocalBusiness` + founder `Person`s + `WebSite` in layout `<head>`; per-project `CreativeWork` + `WebPage` + `BreadcrumbList` in `app/[locale]/projekty/[slug]/page.tsx`; per-service `Service` + `WebPage` + `BreadcrumbList` in `app/[locale]/oferta/[service]/page.tsx` — markup must always match visible, confirmed content (never `ProfessionalService`, `Offer`, ratings, or unconfirmed facts)
 - Dynamic sitemap at `app/sitemap.ts` covers all locale + page + project combinations
 - `/llms.txt` for LLM discovery — generated from `data/projects.ts` + `data/press.ts` in `app/llms.txt/route.ts` (never hand-edit project facts)
 - Crawlability invariants: nav links stay in the server HTML (Navbar animates visibility by state, no conditional mounting) and the projects listing grid is server-rendered from `searchParams`

--- a/app/[locale]/kontakt/KontaktPage.tsx
+++ b/app/[locale]/kontakt/KontaktPage.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl';
 import Navbar from '@/components/Navbar';
 import AddressBlock from '@/components/AddressBlock';
 import FooterBar from '@/components/FooterBar';
+import BriefForm from '@/components/kontakt/BriefForm';
 import { useReducedMotion } from '@/hooks/useReducedMotion';
 
 export default function KontaktPage() {
@@ -15,7 +16,10 @@ export default function KontaktPage() {
     <>
       <Navbar />
       <main className="min-h-dvh pt-[80px] flex flex-col relative">
-        <div className="flex-1 max-w-[1400px] mx-auto px-5 md:px-10 lg:px-12 w-full flex flex-col justify-between pb-[calc(5rem+env(safe-area-inset-bottom))]">
+        {/* Hero block keeps its first-screen layout: heading pinned to the top,
+            showreel + address to the bottom of the viewport. min-h (instead of
+            flex-1) lets the brief form flow below without collapsing it. */}
+        <div className="min-h-[calc(100dvh-80px)] max-w-[1400px] mx-auto px-5 md:px-10 lg:px-12 w-full flex flex-col justify-between pb-[calc(5rem+env(safe-area-inset-bottom))]">
           <motion.div
             className="pt-[20vh] md:pt-[25vh]"
             initial={{ opacity: 0, x: reduceMotion ? 0 : -18 }}
@@ -48,6 +52,15 @@ export default function KontaktPage() {
             <AddressBlock />
           </motion.div>
         </div>
+
+        {/* Qualifying project brief — a second section below the hero */}
+        <section id="brief" className="border-t border-dark/15">
+          <div className="max-w-[1400px] mx-auto px-5 md:px-10 lg:px-12 w-full pt-16 md:pt-24 pb-[calc(6rem+env(safe-area-inset-bottom))]">
+            <div className="max-w-[820px]">
+              <BriefForm />
+            </div>
+          </div>
+        </section>
 
         {/* Fixed bottom bar: instagram + language toggle */}
         <FooterBar />

--- a/app/[locale]/kontakt/actions.ts
+++ b/app/[locale]/kontakt/actions.ts
@@ -1,0 +1,142 @@
+'use server';
+
+import {
+  validateBrief,
+  isBriefValid,
+  buildBriefSubject,
+  buildBriefText,
+  buildMailtoHref,
+  BRIEF_CONTACT_EMAIL,
+  type BriefRawInput,
+  type NormalizedBrief,
+} from '@/lib/brief';
+import type { BriefEchoValues, BriefFormState } from './brief-state';
+
+function readForm(formData: FormData): BriefRawInput {
+  const one = (key: string) => {
+    const v = formData.get(key);
+    return typeof v === 'string' ? v : undefined;
+  };
+  const many = (key: string) =>
+    formData.getAll(key).filter((v): v is string => typeof v === 'string');
+
+  return {
+    name: one('name'),
+    email: one('email'),
+    projectType: one('projectType'),
+    location: one('location'),
+    stage: one('stage'),
+    area: one('area'),
+    startDate: one('startDate'),
+    completionDate: one('completionDate'),
+    scope: many('scope'),
+    budget: one('budget'),
+    priorities: one('priorities'),
+    plansUrl: one('plansUrl'),
+    company: one('company'),
+    ts: one('ts'),
+  };
+}
+
+function echo(raw: BriefRawInput): BriefEchoValues {
+  return {
+    name: raw.name ?? '',
+    email: raw.email ?? '',
+    projectType: raw.projectType ?? '',
+    location: raw.location ?? '',
+    stage: raw.stage ?? '',
+    area: raw.area ?? '',
+    startDate: raw.startDate ?? '',
+    completionDate: raw.completionDate ?? '',
+    scope: raw.scope ?? [],
+    budget: raw.budget ?? '',
+    priorities: raw.priorities ?? '',
+    plansUrl: raw.plansUrl ?? '',
+  };
+}
+
+async function deliverViaResend(
+  apiKey: string,
+  values: NormalizedBrief,
+  subject: string,
+  body: string
+): Promise<boolean> {
+  try {
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: process.env.BRIEF_FROM_EMAIL || 'onboarding@resend.dev',
+        to: [process.env.BRIEF_TO_EMAIL || BRIEF_CONTACT_EMAIL],
+        reply_to: values.email,
+        subject,
+        text: body,
+      }),
+      // Never let a slow provider hang the request indefinitely.
+      signal: AbortSignal.timeout(10_000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Server action wired to the form via useActionState. Validates, screens for
+ * spam, then either delivers through Resend (when configured) or returns a
+ * mailto fallback the client opens. Never throws — always returns a state.
+ */
+export async function submitBrief(
+  _prev: BriefFormState,
+  formData: FormData
+): Promise<BriefFormState> {
+  const raw = readForm(formData);
+  const result = validateBrief(raw);
+  const values = echo(raw);
+  const now = Date.now();
+
+  // Spam (honeypot / too-fast): reject with a generic message, no detail.
+  if (result.spam) {
+    return { status: 'error', formError: 'generic', values, submittedAt: now };
+  }
+
+  // Field errors: return per-field codes and preserve input.
+  if (!isBriefValid(result)) {
+    return { status: 'invalid', errors: result.errors, values, submittedAt: now };
+  }
+
+  const clean = result.values;
+  const subject = buildBriefSubject(clean);
+  const body = buildBriefText(clean);
+
+  const apiKey = process.env.RESEND_API_KEY;
+
+  if (apiKey) {
+    const ok = await deliverViaResend(apiKey, clean, subject, body);
+    if (ok) {
+      return { status: 'success', submitted: clean, submittedAt: now };
+    }
+    // Configured but the send failed: fall back to the user's mail client so
+    // the brief is not lost.
+    return {
+      status: 'fallback',
+      fallback: { reason: 'delivery-failed', mailtoHref: buildMailtoHref(subject, body) },
+      submitted: clean,
+      values,
+      submittedAt: now,
+    };
+  }
+
+  // No delivery configured (current state): the client opens a prefilled
+  // mailto to hello@koolstudio.pl with the same structured body.
+  return {
+    status: 'fallback',
+    fallback: { reason: 'unconfigured', mailtoHref: buildMailtoHref(subject, body) },
+    submitted: clean,
+    values,
+    submittedAt: now,
+  };
+}

--- a/app/[locale]/kontakt/brief-state.ts
+++ b/app/[locale]/kontakt/brief-state.ts
@@ -1,0 +1,45 @@
+// Brief-form action state — shared between the server action (actions.ts) and
+// the client form (BriefForm.tsx). Kept out of the 'use server' module because
+// that file may only export async functions at runtime; a plain const like
+// initialBriefState must live in an ordinary module.
+import type {
+  BriefField,
+  BriefErrorCode,
+  NormalizedBrief,
+} from '@/lib/brief';
+
+// Values echoed back to the form so a failed submit re-populates every field.
+export interface BriefEchoValues {
+  name: string;
+  email: string;
+  projectType: string;
+  location: string;
+  stage: string;
+  area: string;
+  startDate: string;
+  completionDate: string;
+  scope: string[];
+  budget: string;
+  priorities: string;
+  plansUrl: string;
+}
+
+export type BriefStatus = 'idle' | 'success' | 'invalid' | 'error' | 'fallback';
+
+export interface BriefFormState {
+  status: BriefStatus;
+  // field -> error code (client localises)
+  errors?: Partial<Record<BriefField, BriefErrorCode>>;
+  // generic, non-field error code for the status live region
+  formError?: 'generic';
+  // preserved input for re-population after invalid / error / fallback
+  values?: BriefEchoValues;
+  // client opens this mailto when server delivery isn't available
+  fallback?: { reason: 'unconfigured' | 'delivery-failed'; mailtoHref: string };
+  // rendered back on success / fallback so the user sees what was sent
+  submitted?: NormalizedBrief;
+  // new identity per response so the client effect re-runs on repeat submits
+  submittedAt?: number;
+}
+
+export const initialBriefState: BriefFormState = { status: 'idle' };

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -6,8 +6,9 @@ import { NextIntlClientProvider } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 import { locales, type Locale } from '@/i18n/request';
-import { BASE_URL, INSTAGRAM_URL } from '@/lib/site';
+import { BASE_URL } from '@/lib/site';
 import { jsonLdScript } from '@/lib/metadata';
+import { siteGraph } from '@/lib/schema';
 import PageTransition from '@/components/PageTransition';
 import '../globals.css';
 
@@ -72,49 +73,7 @@ export default async function LocaleLayout({
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: jsonLdScript({
-              '@context': 'https://schema.org',
-              '@type': 'ProfessionalService',
-              '@id': `${BASE_URL}/#studio`,
-              name: 'Kool Studio',
-              description: tMeta('schemaDescription'),
-              url: BASE_URL,
-              email: 'hello@koolstudio.pl',
-              image: `${BASE_URL}/images/studio/team.webp`,
-              logo: `${BASE_URL}/logo.svg`,
-              sameAs: [INSTAGRAM_URL],
-              founder: [
-                { '@type': 'Person', name: 'Ola Kilińska' },
-                { '@type': 'Person', name: 'Ola Leszczyńska' },
-              ],
-              address: {
-                '@type': 'PostalAddress',
-                streetAddress: 'Zaporoska 83/15',
-                postalCode: '53-415',
-                addressLocality: 'Wrocław',
-                addressRegion: 'Dolnośląskie',
-                addressCountry: 'PL',
-              },
-              geo: {
-                '@type': 'GeoCoordinates',
-                latitude: 51.09168,
-                longitude: 17.01557,
-              },
-              hasMap: 'https://maps.app.goo.gl/f3nJEyLJXxKStLvPA',
-              areaServed: [
-                { '@type': 'City', name: 'Wrocław' },
-                { '@type': 'City', name: 'Warszawa' },
-                { '@type': 'Country', name: 'Poland' },
-              ],
-              serviceType: [
-                'Interior Architecture',
-                'Interior Design',
-                'Custom Furniture Design',
-                'Lighting Design',
-                'Visual Identity Design',
-              ],
-              knowsLanguage: ['pl', 'en'],
-            }),
+            __html: jsonLdScript(siteGraph(locale, tMeta('schemaDescription'))),
           }}
         />
       </head>

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -10,6 +10,8 @@ import { BASE_URL } from '@/lib/site';
 import { jsonLdScript } from '@/lib/metadata';
 import { siteGraph } from '@/lib/schema';
 import PageTransition from '@/components/PageTransition';
+import GoogleAnalytics from '@/components/GoogleAnalytics';
+import AnalyticsListener from '@/components/AnalyticsListener';
 import '../globals.css';
 
 const poppins = Poppins({
@@ -67,6 +69,10 @@ export default async function LocaleLayout({
   const messages = await getMessages(locale);
   const tMeta = await getTranslations({ locale, namespace: 'meta' });
 
+  // Analytics is inert until a GA4 property id is configured. With no env var
+  // set (current state) nothing below renders and the HTML carries no gtag.
+  const gaId = process.env.NEXT_PUBLIC_GA4_ID;
+
   return (
     <html lang={locale} className={poppins.variable}>
       <head>
@@ -81,6 +87,16 @@ export default async function LocaleLayout({
         <NextIntlClientProvider locale={locale} messages={messages}>
           <PageTransition>{children}</PageTransition>
         </NextIntlClientProvider>
+        {/* GA4 event scaffold — only loads when NEXT_PUBLIC_GA4_ID is set, with
+            Consent Mode v2 defaults denied (cookieless pings until a CMP grants
+            consent; decision-log G4). The click delegate mounts alongside it so
+            it never runs without a gtag to dispatch to. */}
+        {gaId ? (
+          <>
+            <GoogleAnalytics gaId={gaId} />
+            <AnalyticsListener />
+          </>
+        ) : null}
         {/* Cookieless visit counting — needs Web Analytics enabled in the
             Vercel dashboard to start collecting */}
         <Analytics />

--- a/app/[locale]/oferta/OfertaPage.tsx
+++ b/app/[locale]/oferta/OfertaPage.tsx
@@ -28,7 +28,7 @@ export default function OfertaPage() {
 
   return (
     <>
-      <ProjectHero src="/images/oferta/KOOL_oferta_komercyjne.webp" alt="Restaurant interior" />
+      <ProjectHero src="/images/oferta/KOOL_oferta_komercyjne.webp" alt={t('commercialImageAlt')} />
       <Navbar />
       <main>
         {/* Content scrolls over the hero */}
@@ -45,7 +45,7 @@ export default function OfertaPage() {
             scopeTitle={t('scopeTitle')}
             scopeItems={commercialScope}
             scopeImageSrc="/images/oferta/KOOL_oferta_komercyjne_small.webp"
-            scopeImageAlt="Restaurant storefront"
+            scopeImageAlt={t('commercialScopeImageAlt')}
             sloganHeading={t('commercial.sloganHeading')}
             sloganText={t('commercial.sloganText')}
             trustedByLabel={t('commercial.trustedBy')}
@@ -54,7 +54,7 @@ export default function OfertaPage() {
 
           <ParallaxImage
             src="/images/oferta/KOOL_oferta_prywatne.webp"
-            alt="Living room"
+            alt={t('residentialImageAlt')}
             aspect="aspect-[16/9]"
           />
 
@@ -70,14 +70,14 @@ export default function OfertaPage() {
             scopeTitle={t('scopeTitle')}
             scopeItems={residentialScope}
             scopeImageSrc="/images/oferta/KOOL_oferta_prywatne_small.webp"
-            scopeImageAlt="Kitchen interior"
+            scopeImageAlt={t('residentialScopeImageAlt')}
             sloganHeading={t('residential.sloganHeading')}
             sloganText={t('residential.sloganText')}
           />
 
           <ParallaxImage
             src="/images/oferta/KOOL_oferta_finish.webp"
-            alt="Material selection"
+            alt={t('materialsImageAlt')}
             aspect="aspect-[16/9]"
           />
 
@@ -86,7 +86,7 @@ export default function OfertaPage() {
             heading={t('process.heading')}
             steps={processSteps}
             imageSrc="/images/oferta/KOOL_oferta_finish_small.webp"
-            imageAlt="Construction supervision"
+            imageAlt={t('processImageAlt')}
             bottomHeading={t('process.bottomHeading')}
             bottomText={t('process.bottomText')}
           />

--- a/app/[locale]/oferta/OfertaPage.tsx
+++ b/app/[locale]/oferta/OfertaPage.tsx
@@ -8,6 +8,7 @@ import ParallaxImage from '@/components/ParallaxImage';
 import ProjectHero from '@/components/ProjectHero';
 import ServiceSection from '@/components/oferta/ServiceSection';
 import ProcessSection from '@/components/oferta/ProcessSection';
+import ServicesHubLinks from '@/components/oferta/ServicesHubLinks';
 
 export default function OfertaPage() {
   const t = useTranslations('oferta');
@@ -90,6 +91,8 @@ export default function OfertaPage() {
             bottomHeading={t('process.bottomHeading')}
             bottomText={t('process.bottomText')}
           />
+
+          <ServicesHubLinks />
 
           <FooterBanner showMarquee={false} />
         </div>

--- a/app/[locale]/oferta/[service]/page.tsx
+++ b/app/[locale]/oferta/[service]/page.tsx
@@ -141,6 +141,7 @@ export default async function ServiceDetailPage({
       />
       <ServiceLandingPage
         line={service.line}
+        serviceSlug={service.slug}
         heroName={service.heroName}
         heroLead={service.heroLead}
         heroImage={service.heroImage}

--- a/app/[locale]/oferta/[service]/page.tsx
+++ b/app/[locale]/oferta/[service]/page.tsx
@@ -1,0 +1,156 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { getTranslations } from 'next-intl/server';
+import { getService, localizeService, services } from '@/data/services';
+import { localizeProject, projects } from '@/data/projects';
+import { BASE_URL } from '@/lib/site';
+import { jsonLdScript, localeAlternates, ogLocale } from '@/lib/metadata';
+import { ORG_ID, breadcrumbList, webPageNode } from '@/lib/schema';
+import type { Crumb } from '@/components/Breadcrumbs';
+import ServiceLandingPage, { type ProofCard } from '@/components/oferta/ServiceLandingPage';
+
+export function generateStaticParams() {
+  return services.map((service) => ({ service: service.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ service: string; locale: string }>;
+}): Promise<Metadata> {
+  const { service: slug, locale } = await params;
+  const found = getService(slug);
+  if (!found) return {};
+
+  const t = await getTranslations({ locale, namespace: 'meta' });
+  const title = t(`services.${slug}.title`);
+  const description = t(`services.${slug}.description`);
+  const path = `/oferta/${slug}`;
+  const socialImage = {
+    url: found.heroImage,
+    alt: t(`services.${slug}.ogImageAlt`),
+  };
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title: `${title} | kool studio`,
+      description,
+      type: 'website',
+      siteName: 'Kool Studio',
+      locale: ogLocale(locale),
+      alternateLocale: locale === 'en' ? 'pl_PL' : 'en_US',
+      url: `${BASE_URL}/${locale}${path}`,
+      images: [socialImage],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${title} | kool studio`,
+      description,
+      images: [socialImage.url],
+    },
+    alternates: localeAlternates(locale, path),
+  };
+}
+
+export default async function ServiceDetailPage({
+  params,
+}: {
+  params: Promise<{ service: string; locale: string }>;
+}) {
+  const { service: slug, locale } = await params;
+  const found = getService(slug);
+
+  if (!found) {
+    notFound();
+  }
+
+  const service = localizeService(found, locale);
+  const tNav = await getTranslations({ locale, namespace: 'nav' });
+  const tOferta = await getTranslations({ locale, namespace: 'oferta' });
+
+  const canonical = `${BASE_URL}/${locale}/oferta/${slug}`;
+  const serviceId = `${canonical}#service`;
+  const breadcrumbId = `${canonical}#breadcrumb`;
+
+  // Single source for the trail: the visible <Breadcrumbs> and the
+  // BreadcrumbList markup below both derive from it, so they always mirror.
+  const ofertaLabel = tNav('oferta');
+  const crumbs: Crumb[] = [
+    { label: ofertaLabel, href: '/oferta' },
+    { label: service.heroName },
+  ];
+
+  // Proof projects resolved to card facts from data/projects.ts (localized).
+  const proof: ProofCard[] = service.proofSlugs.map((proofSlug) => {
+    const foundProject = projects.find((p) => p.slug === proofSlug);
+    if (!foundProject) throw new Error(`Missing proof project: ${proofSlug}`);
+    const project = localizeProject(foundProject, locale);
+    return {
+      slug: project.slug,
+      title: project.title,
+      location: project.location,
+      area: project.area,
+      year: project.year,
+      thumbnail: project.thumbnail,
+    };
+  });
+
+  // JSON-LD: a Service node (provider → the org) + the page's WebPage and
+  // BreadcrumbList. Description is the exact published service-line copy. No
+  // Offer, price, aggregateRating or FAQPage markup (playbook iron rule).
+  const serviceNode = {
+    '@type': 'Service',
+    '@id': serviceId,
+    name: service.heroName,
+    description: tOferta(`${service.line}.description`),
+    provider: { '@id': ORG_ID },
+    areaServed: [
+      { '@type': 'City', name: 'Wrocław' },
+      { '@type': 'Country', name: 'Poland' },
+    ],
+    serviceType: service.serviceType,
+    url: canonical,
+    inLanguage: locale,
+  };
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      webPageNode({
+        url: canonical,
+        name: service.heroName,
+        locale,
+        about: { '@id': serviceId },
+        breadcrumb: { '@id': breadcrumbId },
+      }),
+      serviceNode,
+      breadcrumbList(breadcrumbId, [
+        { name: ofertaLabel, url: `${BASE_URL}/${locale}/oferta` },
+        { name: service.heroName, url: canonical },
+      ]),
+    ],
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: jsonLdScript(jsonLd) }}
+      />
+      <ServiceLandingPage
+        line={service.line}
+        heroName={service.heroName}
+        heroLead={service.heroLead}
+        heroImage={service.heroImage}
+        heroImageAlt={service.heroImageAlt}
+        crumbs={crumbs}
+        situations={service.situations}
+        proof={proof}
+        proofAngles={service.proofAngles}
+        faqs={service.faqs}
+      />
+    </>
+  );
+}

--- a/app/[locale]/projekty/[slug]/page.tsx
+++ b/app/[locale]/projekty/[slug]/page.tsx
@@ -179,14 +179,6 @@ export default async function ProjectDetailPage({
 
           <ProjectMeta project={project} />
 
-          {project.caseStudy && (
-            <CaseStudySection
-              caseStudy={project.caseStudy}
-              caseId={slug}
-              service={relatedService === 'oferta' ? undefined : relatedService}
-            />
-          )}
-
           <ProjectContent
             images={project.images.slice(1)}
             title={project.title}
@@ -209,6 +201,14 @@ export default async function ProjectDetailPage({
             portraitIndices={project.portraitIndices?.map((i) => i - 1).filter((i) => i >= 0)}
             smallIndices={project.smallIndices?.map((i) => i - 1).filter((i) => i >= 0)}
           />
+
+          {project.caseStudy && (
+            <CaseStudySection
+              caseStudy={project.caseStudy}
+              caseId={slug}
+              service={relatedService === 'oferta' ? undefined : relatedService}
+            />
+          )}
 
           {project.caseStudy && (
             <ProjectServiceCta serviceKey={relatedService} serviceHref={serviceHref} />

--- a/app/[locale]/projekty/[slug]/page.tsx
+++ b/app/[locale]/projekty/[slug]/page.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
+import { getTranslations } from 'next-intl/server';
 import { localizeProject, projects } from '@/data/projects';
 import { BASE_URL } from '@/lib/site';
 import { jsonLdScript, localeAlternates, ogLocale } from '@/lib/metadata';
+import { ORG_ID, breadcrumbList, webPageNode } from '@/lib/schema';
 import Navbar from '@/components/Navbar';
+import Breadcrumbs, { type Crumb } from '@/components/Breadcrumbs';
 import FooterBanner from '@/components/FooterBanner';
 import ProjectHero from '@/components/ProjectHero';
 import ProjectMeta from '@/components/ProjectMeta';
@@ -67,56 +70,85 @@ export default async function ProjectDetailPage({
   }
 
   const project = localizeProject(found, locale);
+  const tNav = await getTranslations({ locale, namespace: 'nav' });
 
   const displayTitle = project.meta?.title ?? project.title;
   const displayLocation = project.meta?.location ?? project.location;
-  const pageUrl = `${BASE_URL}/${locale}/projekty/${slug}`;
+  const canonical = `${BASE_URL}/${locale}/projekty/${slug}`;
+  const heroImage = project.images[0];
   const heroAlt =
     locale === 'en'
       ? `Interior of ${project.title}, ${project.location}`
       : `Wnętrze projektu ${project.title}, ${project.location}`;
 
+  const creativeWorkId = `${canonical}#creativework`;
+  const primaryImageId = `${canonical}#primaryimage`;
+  const breadcrumbId = `${canonical}#breadcrumb`;
+
+  // Single source for the trail: the visible <Breadcrumbs> and the
+  // BreadcrumbList markup below both derive from it, so they always mirror.
+  const projektyLabel = tNav('projekty');
+  const crumbs: Crumb[] = [
+    { label: projektyLabel, href: '/projekty' },
+    { label: displayTitle },
+  ];
+
+  const creativeWork = {
+    '@type': 'CreativeWork',
+    '@id': creativeWorkId,
+    name: `${displayTitle} — ${displayLocation}`,
+    description: project.description,
+    url: canonical,
+    creator: { '@id': ORG_ID },
+    locationCreated: {
+      '@type': 'Place',
+      name: displayLocation,
+      address: { '@type': 'PostalAddress', addressCountry: 'PL' },
+    },
+    dateCreated: String(project.year),
+    genre: project.scope,
+    inLanguage: locale,
+    ...(heroImage ? { image: { '@id': primaryImageId } } : {}),
+    ...(project.meta?.collaboration
+      ? { contributor: { '@type': 'Organization', name: project.meta.collaboration } }
+      : {}),
+  };
+
+  const graph: object[] = [
+    webPageNode({
+      url: canonical,
+      name: `${project.title} / ${project.location}`,
+      locale,
+      mainEntity: { '@id': creativeWorkId },
+      breadcrumb: { '@id': breadcrumbId },
+      ...(heroImage ? { primaryImageOfPage: { '@id': primaryImageId } } : {}),
+    }),
+    creativeWork,
+    breadcrumbList(breadcrumbId, [
+      { name: projektyLabel, url: `${BASE_URL}/${locale}/projekty` },
+      { name: displayTitle, url: canonical },
+    ]),
+  ];
+
+  // Primary image as an ImageObject; photographer credit only from the
+  // project's own photoCredit field (never invented).
+  if (heroImage) {
+    graph.push({
+      '@type': 'ImageObject',
+      '@id': primaryImageId,
+      contentUrl: `${BASE_URL}${heroImage}`,
+      ...(project.photoCredit
+        ? {
+            creditText: project.photoCredit,
+            creator: { '@type': 'Organization', name: project.photoCredit },
+          }
+        : {}),
+    });
+  }
+
   const jsonLd = {
     '@context': 'https://schema.org',
-    '@graph': [
-      {
-        '@type': 'CreativeWork',
-        '@id': `${pageUrl}#project`,
-        name: `${displayTitle} — ${displayLocation}`,
-        description: project.description,
-        url: pageUrl,
-        image: project.images.map((image) => `${BASE_URL}${image}`),
-        dateCreated: String(project.year),
-        locationCreated: {
-          '@type': 'Place',
-          name: displayLocation,
-          address: { '@type': 'PostalAddress', addressCountry: 'PL' },
-        },
-        creator: {
-          '@type': 'ProfessionalService',
-          '@id': `${BASE_URL}/#studio`,
-          name: 'Kool Studio',
-          url: BASE_URL,
-        },
-        ...(project.meta?.collaboration
-          ? { contributor: { '@type': 'Organization', name: project.meta.collaboration } }
-          : {}),
-        inLanguage: locale,
-      },
-      {
-        '@type': 'BreadcrumbList',
-        itemListElement: [
-          { '@type': 'ListItem', position: 1, name: 'kool studio', item: `${BASE_URL}/${locale}` },
-          {
-            '@type': 'ListItem',
-            position: 2,
-            name: locale === 'en' ? 'projects' : 'projekty',
-            item: `${BASE_URL}/${locale}/projekty`,
-          },
-          { '@type': 'ListItem', position: 3, name: displayTitle, item: pageUrl },
-        ],
-      },
-    ],
+    '@graph': graph,
   };
 
   return (
@@ -132,6 +164,10 @@ export default async function ProjectDetailPage({
       <main>
         {/* Content scrolls over the hero */}
         <div className="relative z-10 bg-beige">
+          <div className="px-5 pt-10 md:px-10 md:pt-14 lg:px-12">
+            <Breadcrumbs items={crumbs} />
+          </div>
+
           <ProjectMeta project={project} />
 
           <ProjectContent

--- a/app/[locale]/projekty/[slug]/page.tsx
+++ b/app/[locale]/projekty/[slug]/page.tsx
@@ -27,6 +27,9 @@ export async function generateMetadata({
 
   const title = `${project.title} / ${project.location}`;
   const description = project.description;
+  const ogImages = project.images[0]
+    ? [{ url: project.images[0], alt: `${project.title}, ${project.location} — kool studio` }]
+    : undefined;
 
   return {
     title,
@@ -35,8 +38,17 @@ export async function generateMetadata({
       title: `${title} | kool studio`,
       description,
       type: 'article',
+      siteName: 'Kool Studio',
       locale: ogLocale(locale),
-      images: project.images[0] ? [{ url: project.images[0] }] : undefined,
+      alternateLocale: locale === 'en' ? 'pl_PL' : 'en_US',
+      url: `${BASE_URL}/${locale}/projekty/${slug}`,
+      images: ogImages,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${title} | kool studio`,
+      description,
+      images: project.images[0] ? [project.images[0]] : undefined,
     },
     alternates: localeAlternates(locale, `/projekty/${slug}`),
   };
@@ -59,6 +71,10 @@ export default async function ProjectDetailPage({
   const displayTitle = project.meta?.title ?? project.title;
   const displayLocation = project.meta?.location ?? project.location;
   const pageUrl = `${BASE_URL}/${locale}/projekty/${slug}`;
+  const heroAlt =
+    locale === 'en'
+      ? `Interior of ${project.title}, ${project.location}`
+      : `Wnętrze projektu ${project.title}, ${project.location}`;
 
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -110,7 +126,7 @@ export default async function ProjectDetailPage({
         dangerouslySetInnerHTML={{ __html: jsonLdScript(jsonLd) }}
       />
       {project.images[0] && (
-        <ProjectHero src={project.images[0]} alt={project.title} />
+        <ProjectHero src={project.images[0]} alt={heroAlt} />
       )}
       <Navbar />
       <main>
@@ -120,6 +136,8 @@ export default async function ProjectDetailPage({
 
           <ProjectContent
             images={project.images.slice(1)}
+            title={project.title}
+            location={project.location}
             description={project.description}
             descriptionBlocks={project.descriptionBlocks}
             fullWidthIndices={project.fullWidthIndices?.map((i) => i - 1).filter((i) => i >= 0)}

--- a/app/[locale]/projekty/[slug]/page.tsx
+++ b/app/[locale]/projekty/[slug]/page.tsx
@@ -179,7 +179,13 @@ export default async function ProjectDetailPage({
 
           <ProjectMeta project={project} />
 
-          {project.caseStudy && <CaseStudySection caseStudy={project.caseStudy} />}
+          {project.caseStudy && (
+            <CaseStudySection
+              caseStudy={project.caseStudy}
+              caseId={slug}
+              service={relatedService === 'oferta' ? undefined : relatedService}
+            />
+          )}
 
           <ProjectContent
             images={project.images.slice(1)}

--- a/app/[locale]/projekty/[slug]/page.tsx
+++ b/app/[locale]/projekty/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getTranslations } from 'next-intl/server';
-import { localizeProject, projects } from '@/data/projects';
+import { localizeProject, projects, relatedServiceSlug } from '@/data/projects';
 import { BASE_URL } from '@/lib/site';
 import { jsonLdScript, localeAlternates, ogLocale } from '@/lib/metadata';
 import { ORG_ID, breadcrumbList, webPageNode } from '@/lib/schema';
@@ -11,6 +11,8 @@ import FooterBanner from '@/components/FooterBanner';
 import ProjectHero from '@/components/ProjectHero';
 import ProjectMeta from '@/components/ProjectMeta';
 import ProjectContent from '@/components/ProjectContent';
+import CaseStudySection from '@/components/CaseStudySection';
+import ProjectServiceCta from '@/components/ProjectServiceCta';
 
 export function generateStaticParams() {
   return projects.map((project) => ({
@@ -85,6 +87,10 @@ export default async function ProjectDetailPage({
   const primaryImageId = `${canonical}#primaryimage`;
   const breadcrumbId = `${canonical}#breadcrumb`;
 
+  // Case → service cross-link target (category heuristic + explicit overrides).
+  const relatedService = relatedServiceSlug(found);
+  const serviceHref = relatedService === 'oferta' ? '/oferta' : `/oferta/${relatedService}`;
+
   // Single source for the trail: the visible <Breadcrumbs> and the
   // BreadcrumbList markup below both derive from it, so they always mirror.
   const projektyLabel = tNav('projekty');
@@ -108,6 +114,9 @@ export default async function ProjectDetailPage({
     dateCreated: String(project.year),
     genre: project.scope,
     inLanguage: locale,
+    // The published problem statement, only when a case block restates it —
+    // no invented facts (SEO playbook iron rule).
+    ...(project.caseStudy ? { abstract: project.caseStudy.problem } : {}),
     ...(heroImage ? { image: { '@id': primaryImageId } } : {}),
     ...(project.meta?.collaboration
       ? { contributor: { '@type': 'Organization', name: project.meta.collaboration } }
@@ -170,6 +179,8 @@ export default async function ProjectDetailPage({
 
           <ProjectMeta project={project} />
 
+          {project.caseStudy && <CaseStudySection caseStudy={project.caseStudy} />}
+
           <ProjectContent
             images={project.images.slice(1)}
             title={project.title}
@@ -192,6 +203,10 @@ export default async function ProjectDetailPage({
             portraitIndices={project.portraitIndices?.map((i) => i - 1).filter((i) => i >= 0)}
             smallIndices={project.smallIndices?.map((i) => i - 1).filter((i) => i >= 0)}
           />
+
+          {project.caseStudy && (
+            <ProjectServiceCta serviceKey={relatedService} serviceHref={serviceHref} />
+          )}
 
           <FooterBanner showMarquee={false} />
         </div>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from 'next';
 import { projects } from '@/data/projects';
+import { services } from '@/data/services';
 import { BASE_URL } from '@/lib/site';
 
 // No lastModified: the repo has no real per-URL modification timestamp, and
@@ -18,6 +19,14 @@ export default function sitemap(): MetadataRoute.Sitemap {
     }))
   );
 
+  // Service landing pages (children of /oferta), one per locale.
+  const serviceEntries = locales.flatMap((locale) =>
+    services.map((service) => ({
+      url: `${BASE_URL}/${locale}/oferta/${service.slug}`,
+      priority: 0.8,
+    }))
+  );
+
   const projectEntries = locales.flatMap((locale) =>
     projects.map((project) => ({
       url: `${BASE_URL}/${locale}/projekty/${project.slug}`,
@@ -25,5 +34,5 @@ export default function sitemap(): MetadataRoute.Sitemap {
     }))
   );
 
-  return [...staticEntries, ...projectEntries];
+  return [...staticEntries, ...serviceEntries, ...projectEntries];
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,6 +2,10 @@ import type { MetadataRoute } from 'next';
 import { projects } from '@/data/projects';
 import { BASE_URL } from '@/lib/site';
 
+// No lastModified: the repo has no real per-URL modification timestamp, and
+// stamping new Date() on every build fabricates freshness. changeFrequency is
+// likewise omitted — asserting a cadence we can't substantiate. priority is a
+// genuine relative-importance hint and is kept.
 export default function sitemap(): MetadataRoute.Sitemap {
   const locales = ['pl', 'en'];
 
@@ -10,8 +14,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const staticEntries = locales.flatMap((locale) =>
     staticPages.map((page) => ({
       url: `${BASE_URL}/${locale}${page}`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly' as const,
       priority: page === '' ? 1.0 : 0.8,
     }))
   );
@@ -19,8 +21,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const projectEntries = locales.flatMap((locale) =>
     projects.map((project) => ({
       url: `${BASE_URL}/${locale}/projekty/${project.slug}`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly' as const,
       priority: 0.9,
     }))
   );

--- a/components/AddressBlock.tsx
+++ b/components/AddressBlock.tsx
@@ -35,6 +35,7 @@ export default function AddressBlock() {
       <a
         href="mailto:hello@koolstudio.pl"
         aria-label={email}
+        data-analytics-position="footer"
         className="flex justify-between w-full font-[700] uppercase text-dark hover:opacity-70 transition-opacity text-[clamp(18px,6.2vw,55px)] md:block md:whitespace-nowrap md:text-right md:text-[clamp(32px,4.2vw,55px)]"
       >
         <Distributed text={email} />

--- a/components/AnalyticsListener.tsx
+++ b/components/AnalyticsListener.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { usePathname } from '@/i18n/navigation';
+import { pageTypeFromPath, trackCtaClick, trackEmailClick } from '@/lib/analytics';
+
+// One document-level click delegate, mounted once in the layout ONLY when GA4
+// is configured. It lets server components stay server components: they only
+// gain inert `data-analytics` attributes, and this client listener reads them.
+//
+//   cta_click   — any element with data-analytics="cta_click", reading
+//                 data-analytics-service, data-analytics-cta-text,
+//                 data-analytics-position.
+//   email_click — any `a[href^="mailto:"]` (position from data-analytics-position,
+//                 default "footer"); skipped when the anchor is inside a
+//                 [data-analytics-skip] region (e.g. the brief mailto fallback,
+//                 which reports brief_mailto_fallback instead).
+//
+// page_type is derived centrally from the route, so individual elements never
+// need to repeat it. The handler never throws and never calls preventDefault,
+// so navigation is untouched.
+export default function AnalyticsListener() {
+  const pathname = usePathname();
+  // Keep the latest path in a ref so the once-attached handler always reads it.
+  const pathRef = useRef(pathname);
+  useEffect(() => {
+    pathRef.current = pathname;
+  }, [pathname]);
+
+  useEffect(() => {
+    function onClick(event: MouseEvent) {
+      try {
+        const target = event.target;
+        if (!(target instanceof Element)) return;
+
+        // 1) Explicit CTA elements.
+        const cta = target.closest('[data-analytics="cta_click"]');
+        if (cta instanceof HTMLElement) {
+          const data = cta.dataset;
+          const rawText = data.analyticsCtaText ?? cta.textContent ?? '';
+          const ctaText = rawText.replace(/→/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 80);
+          trackCtaClick({
+            page_type: pageTypeFromPath(pathRef.current),
+            service: data.analyticsService || undefined,
+            cta_text: ctaText,
+            position: data.analyticsPosition || 'unknown',
+          });
+          return;
+        }
+
+        // 2) Email links — never read the address, only page_type + position.
+        const mailto = target.closest('a[href^="mailto:"]');
+        if (mailto instanceof HTMLAnchorElement) {
+          if (mailto.closest('[data-analytics-skip]')) return;
+          trackEmailClick({
+            page_type: pageTypeFromPath(pathRef.current),
+            position: mailto.dataset.analyticsPosition || 'footer',
+          });
+        }
+      } catch {
+        // A listener must never break the page.
+      }
+    }
+
+    // Capture phase so the event is recorded before a client-side navigation.
+    document.addEventListener('click', onClick, true);
+    return () => document.removeEventListener('click', onClick, true);
+  }, []);
+
+  return null;
+}

--- a/components/BeforeAfterSlider.tsx
+++ b/components/BeforeAfterSlider.tsx
@@ -12,9 +12,15 @@ interface BeforeAfterSliderProps {
   /** 'overlay' places labels on the image corners (photos); 'above' puts them
       just over the frame (plans/drawings the labels would otherwise cover). */
   labelPosition?: 'overlay' | 'above';
+  /** Descriptive alt text for the two frames (falls back to the labels). */
+  beforeAlt?: string;
+  afterAlt?: string;
+  /** Rendered-width hint for the frames (default "100vw"). Pass the real
+      width when the slider sits in a narrower slot (e.g. a 50/50 row). */
+  sizes?: string;
 }
 
-export default function BeforeAfterSlider({ beforeSrc, afterSrc, beforeLabel, afterLabel, aspectClass = 'aspect-[3/2]', labelPosition = 'overlay' }: BeforeAfterSliderProps) {
+export default function BeforeAfterSlider({ beforeSrc, afterSrc, beforeLabel, afterLabel, aspectClass = 'aspect-[3/2]', labelPosition = 'overlay', beforeAlt, afterAlt, sizes = '100vw' }: BeforeAfterSliderProps) {
   const [position, setPosition] = useState(50);
   const [touched, setTouched] = useState(false);
   const [inView, setInView] = useState(false);
@@ -100,7 +106,7 @@ export default function BeforeAfterSlider({ beforeSrc, afterSrc, beforeLabel, af
       >
         {/* After (right/full) */}
         <div className="absolute inset-0 bg-beige">
-          <Image src={afterSrc} alt="po" fill className="object-contain" sizes="100vw" />
+          <Image src={afterSrc} alt={afterAlt ?? afterLabel ?? ''} fill className="object-contain" sizes={sizes} />
         </div>
 
         {/* Before (left, clipped) */}
@@ -108,7 +114,7 @@ export default function BeforeAfterSlider({ beforeSrc, afterSrc, beforeLabel, af
           className="absolute inset-0 bg-beige"
           style={{ clipPath: `inset(0 ${100 - position}% 0 0)` }}
         >
-          <Image src={beforeSrc} alt="przed" fill className="object-contain" sizes="100vw" />
+          <Image src={beforeSrc} alt={beforeAlt ?? beforeLabel ?? ''} fill className="object-contain" sizes={sizes} />
         </div>
 
         {/* Labels */}

--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -1,0 +1,49 @@
+import { Link } from '@/i18n/navigation';
+
+// One crumb in the trail. Ancestors carry an `href` (locale-prefixed by
+// next-intl's Link); the current page omits it. Server-renderable so the
+// links stay in the crawlable HTML — and reusable by any section (project
+// detail, oferta subpages, …) that passes its own ordered items.
+export type Crumb = {
+  label: string;
+  href?: string;
+};
+
+export default function Breadcrumbs({
+  items,
+  className,
+}: {
+  items: Crumb[];
+  className?: string;
+}) {
+  return (
+    <nav aria-label="Breadcrumb" className={className}>
+      <ol className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] md:text-[12px] font-[600] uppercase tracking-[0.15em]">
+        {items.map((item, index) => {
+          const isLast = index === items.length - 1;
+          return (
+            <li key={index} className="flex items-center gap-x-3">
+              {item.href && !isLast ? (
+                <Link
+                  href={item.href}
+                  className="text-muted transition-colors duration-200 hover:text-dark"
+                >
+                  {item.label}
+                </Link>
+              ) : (
+                <span className="text-dark" aria-current={isLast ? 'page' : undefined}>
+                  {item.label}
+                </span>
+              )}
+              {!isLast && (
+                <span aria-hidden="true" className="text-muted">
+                  /
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/components/CaseStudySection.tsx
+++ b/components/CaseStudySection.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { useTranslations } from 'next-intl';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+import type { CaseStudy } from '@/data/projects';
+
+const EASE: [number, number, number, number] = [0.22, 1, 0.36, 1];
+
+interface CaseStudySectionProps {
+  caseStudy: CaseStudy;
+}
+
+/* Structured case block for a project detail page: a real problem → design
+   decisions → result arc, restated from the project's own published copy.
+   Editorial dark type on beige, small coral labels, subtle fade-in. Rendered
+   only when a project carries a caseStudy, so pages without one are unchanged. */
+export default function CaseStudySection({ caseStudy }: CaseStudySectionProps) {
+  const t = useTranslations('caseStudy');
+  const reduceMotion = useReducedMotion();
+
+  const fade = {
+    initial: { opacity: 0, y: reduceMotion ? 0 : 16 },
+    whileInView: { opacity: 1, y: 0 },
+    viewport: { once: true, amount: 0.2 },
+    transition: { duration: reduceMotion ? 0 : 0.7, ease: EASE },
+  };
+
+  return (
+    <section className="border-t border-coral/40">
+      <div className="max-w-content mx-auto px-5 md:px-10 lg:px-12 py-14 md:py-20">
+        <span
+          className="font-[600] uppercase text-coral tracking-[0.14em] block"
+          style={{ fontSize: 'clamp(12px, 1.1vw, 14px)' }}
+        >
+          {t('sectionLabel')}
+        </span>
+
+        <div className="mt-8 md:mt-12 flex flex-col divide-y divide-dark/10">
+          {/* Challenge — the real starting constraint, as published */}
+          <motion.div
+            {...fade}
+            className="grid gap-4 md:gap-10 md:grid-cols-[minmax(160px,0.26fr)_1fr] py-8 md:py-10 first:pt-0"
+          >
+            <h2
+              className="font-[700] uppercase text-dark tracking-[0.06em] leading-[1.2]"
+              style={{ fontSize: 'clamp(13px, 1.2vw, 16px)' }}
+            >
+              {t('challenge')}
+            </h2>
+            <p
+              className="text-dark font-[400] leading-[1.6] max-w-[820px]"
+              style={{ fontSize: 'clamp(15px, 1.35vw, 18px)' }}
+            >
+              {caseStudy.problem}
+            </p>
+          </motion.div>
+
+          {/* Design decisions — each traceable to a published sentence */}
+          <motion.div
+            {...fade}
+            className="grid gap-4 md:gap-10 md:grid-cols-[minmax(160px,0.26fr)_1fr] py-8 md:py-10"
+          >
+            <h2
+              className="font-[700] uppercase text-dark tracking-[0.06em] leading-[1.2]"
+              style={{ fontSize: 'clamp(13px, 1.2vw, 16px)' }}
+            >
+              {t('decisions')}
+            </h2>
+            <ol className="flex flex-col gap-4 md:gap-5 max-w-[820px]">
+              {caseStudy.decisions.map((decision, i) => (
+                <li key={i} className="flex items-start gap-4 md:gap-5">
+                  <span
+                    className="text-coral font-[700] tabular-nums shrink-0 leading-[1.5]"
+                    style={{ fontSize: 'clamp(13px, 1.2vw, 16px)' }}
+                  >
+                    {String(i + 1).padStart(2, '0')}
+                  </span>
+                  <span
+                    className="text-dark font-[400] leading-[1.6]"
+                    style={{ fontSize: 'clamp(15px, 1.35vw, 18px)' }}
+                  >
+                    {decision}
+                  </span>
+                </li>
+              ))}
+            </ol>
+          </motion.div>
+
+          {/* Result — the outcome as published (qualitative) */}
+          <motion.div
+            {...fade}
+            className="grid gap-4 md:gap-10 md:grid-cols-[minmax(160px,0.26fr)_1fr] py-8 md:py-10 last:pb-0"
+          >
+            <h2
+              className="font-[700] uppercase text-dark tracking-[0.06em] leading-[1.2]"
+              style={{ fontSize: 'clamp(13px, 1.2vw, 16px)' }}
+            >
+              {t('result')}
+            </h2>
+            <p
+              className="text-dark font-[400] leading-[1.6] max-w-[820px]"
+              style={{ fontSize: 'clamp(15px, 1.35vw, 18px)' }}
+            >
+              {caseStudy.result}
+            </p>
+          </motion.div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/CaseStudySection.tsx
+++ b/components/CaseStudySection.tsx
@@ -1,23 +1,60 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { motion } from 'framer-motion';
 import { useTranslations } from 'next-intl';
+import { usePathname } from '@/i18n/navigation';
 import { useReducedMotion } from '@/hooks/useReducedMotion';
+import { analyticsEnabled, trackCaseEngaged } from '@/lib/analytics';
 import type { CaseStudy } from '@/data/projects';
 
 const EASE: [number, number, number, number] = [0.22, 1, 0.36, 1];
 
 interface CaseStudySectionProps {
   caseStudy: CaseStudy;
+  // Non-PII case identifier (the project slug) + optional related service slug,
+  // used for the `case_engaged` analytics event only.
+  caseId: string;
+  service?: string;
 }
 
 /* Structured case block for a project detail page: a real problem → design
    decisions → result arc, restated from the project's own published copy.
    Editorial dark type on beige, small coral labels, subtle fade-in. Rendered
    only when a project carries a caseStudy, so pages without one are unchanged. */
-export default function CaseStudySection({ caseStudy }: CaseStudySectionProps) {
+export default function CaseStudySection({ caseStudy, caseId, service }: CaseStudySectionProps) {
   const t = useTranslations('caseStudy');
   const reduceMotion = useReducedMotion();
+  const pathname = usePathname();
+  const rootRef = useRef<HTMLElement>(null);
+  // Once-per-page-view guard, keyed by route so a client navigation to another
+  // project re-arms the observer.
+  const firedForPath = useRef<string | null>(null);
+
+  // case_engaged: fire when the case block actually enters the viewport
+  // (threshold ~0.4), at most once per page view. Inert unless GA4 is
+  // configured, so the un-instrumented site attaches no observer.
+  useEffect(() => {
+    if (!analyticsEnabled) return;
+    const el = rootRef.current;
+    if (!el || typeof IntersectionObserver === 'undefined') return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting && firedForPath.current !== pathname) {
+            firedForPath.current = pathname;
+            trackCaseEngaged({ case_id: caseId, service });
+            observer.disconnect();
+          }
+        }
+      },
+      { threshold: 0.4 }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [pathname, caseId, service]);
 
   const fade = {
     initial: { opacity: 0, y: reduceMotion ? 0 : 16 },
@@ -27,7 +64,7 @@ export default function CaseStudySection({ caseStudy }: CaseStudySectionProps) {
   };
 
   return (
-    <section className="border-t border-coral/40">
+    <section ref={rootRef} className="border-t border-coral/40">
       <div className="max-w-content mx-auto px-5 md:px-10 lg:px-12 py-14 md:py-20">
         <span
           className="font-[600] uppercase text-coral tracking-[0.14em] block"

--- a/components/GoogleAnalytics.tsx
+++ b/components/GoogleAnalytics.tsx
@@ -1,0 +1,46 @@
+import Script from 'next/script';
+
+// GA4 loader, rendered by the root layout ONLY when NEXT_PUBLIC_GA4_ID is set.
+// When the env var is absent, the layout renders nothing and the built HTML
+// contains zero gtag / googletagmanager references.
+//
+// Consent Mode v2: the inline script sets every storage signal to `denied`
+// BEFORE `config` runs, so GA4 operates in cookieless-ping mode until a CMP
+// (decision-log G4) grants analytics_storage via grantAnalyticsConsent().
+// The `gtag` function is declared at the top level of a classic inline script,
+// so it becomes window.gtag — which lib/analytics.ts dispatches through.
+
+// GA4 measurement ids look like `G-XXXXXXXXXX`. Validate before interpolating
+// into an inline script so a malformed env value can never inject markup.
+const GA4_ID_PATTERN = /^G-[A-Z0-9]+$/i;
+
+export default function GoogleAnalytics({ gaId }: { gaId: string }) {
+  if (!GA4_ID_PATTERN.test(gaId)) return null;
+
+  return (
+    <>
+      <Script id="ga-consent-default" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('consent', 'default', {
+            ad_storage: 'denied',
+            ad_user_data: 'denied',
+            ad_personalization: 'denied',
+            analytics_storage: 'denied'
+          });
+          gtag('js', new Date());
+          gtag('config', '${gaId}', {
+            anonymize_ip: true,
+            send_page_view: true
+          });
+        `}
+      </Script>
+      <Script
+        id="ga-gtag"
+        strategy="afterInteractive"
+        src={`https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(gaId)}`}
+      />
+    </>
+  );
+}

--- a/components/ImageStrip.tsx
+++ b/components/ImageStrip.tsx
@@ -21,7 +21,9 @@ function slideAlt(slug: string, locale: string): string {
   const project = projects.find((p) => p.slug === slug);
   if (!project) return 'Kool Studio project';
   const localized = localizeProject(project, locale);
-  return `${localized.title} ${localized.location}`;
+  return locale === 'en'
+    ? `Interior of ${localized.title}, ${localized.location}`
+    : `Wnętrze projektu ${localized.title}, ${localized.location}`;
 }
 
 function shuffle<T>(items: T[]): T[] {

--- a/components/ManifestoSection.tsx
+++ b/components/ManifestoSection.tsx
@@ -47,7 +47,7 @@ export default function ManifestoSection() {
       <section className="mt-[60px] md:mt-[80px]">
         <div className="flex flex-col md:flex-row">
           <ManifestoText heading={t('section1Heading')} text={t('section1Text')} />
-          <ManifestoImage src="/images/home/kool_main_01.webp" alt="Material moodboard" />
+          <ManifestoImage src="/images/home/kool_main_01.webp" alt={t('section1ImageAlt')} />
         </div>
       </section>
 
@@ -69,7 +69,7 @@ export default function ManifestoSection() {
       {/* Section 2: image left, text right — project-page 50/50 row */}
       <section className="mb-[80px] md:mb-[120px]">
         <div className="flex flex-col md:flex-row">
-          <ManifestoImage src="/images/home/kool_main_02.webp" alt="Interior photography" />
+          <ManifestoImage src="/images/home/kool_main_02.webp" alt={t('section2ImageAlt')} />
           <ManifestoText heading={t('section2Heading')} text={t('section2Text')} />
         </div>
       </section>

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { Link } from '@/i18n/navigation';
 import type { Project } from '@/data/projects';
 
@@ -11,6 +11,11 @@ interface ProjectCardProps {
 
 export default function ProjectCard({ project }: ProjectCardProps) {
   const t = useTranslations('projects');
+  const locale = useLocale();
+  const thumbnailAlt =
+    locale === 'en'
+      ? `Interior of ${project.title}, ${project.location}`
+      : `Wnętrze projektu ${project.title}, ${project.location}`;
 
   return (
     <div>
@@ -19,7 +24,7 @@ export default function ProjectCard({ project }: ProjectCardProps) {
           <div className="relative aspect-square">
             <Image
               src={project.thumbnail}
-              alt={project.title}
+              alt={thumbnailAlt}
               fill
               className="object-cover transition-transform duration-[600ms] group-hover:scale-[1.04]"
               sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"

--- a/components/ProjectContent.tsx
+++ b/components/ProjectContent.tsx
@@ -1,18 +1,22 @@
 'use client';
 
 import Image from 'next/image';
+import { useLocale } from 'next-intl';
 import BeforeAfterSlider from './BeforeAfterSlider';
 import ColumnImage from './ColumnImage';
 import ParallaxImage from './ParallaxImage';
 
 type SliderData = { beforeSrc: string; afterSrc: string; labels?: [string, string]; aspect?: string };
 type Item =
-  | { kind: 'image'; src: string }
-  | { kind: 'reel'; src: string; aspect?: string }
-  | ({ kind: 'slider' } & SliderData);
+  | { kind: 'image'; src: string; alt: string }
+  | { kind: 'reel'; src: string; aspect?: string; alt: string }
+  | ({ kind: 'slider' } & SliderData & { beforeAlt: string; afterAlt: string });
 
 interface ProjectContentProps {
   images: string[];
+  // Localized project title/location — used to build descriptive image alts
+  title: string;
+  location: string;
   description: string;
   descriptionBlocks?: string[];
   fullWidthIndices?: number[];
@@ -30,12 +34,12 @@ interface ProjectContentProps {
   smallIndices?: number[];
 }
 
-function PaddedImage({ src, small }: { src: string; small?: boolean }) {
+function PaddedImage({ src, alt, small }: { src: string; alt: string; small?: boolean }) {
   if (small) {
     return (
       <ColumnImage
         src={src}
-        alt="Kool Studio project"
+        alt={alt}
         aspect="aspect-[9/16]"
         width="w-[72%] md:w-[60%]"
         fit="contain"
@@ -48,21 +52,21 @@ function PaddedImage({ src, small }: { src: string; small?: boolean }) {
   return (
     <div className="w-full md:w-1/2 p-6 md:p-10 lg:p-14 xl:p-20">
       <div className="relative w-full h-full aspect-[3/4] md:aspect-auto">
-        <Image src={src} alt="Kool Studio project" fill className="object-contain" sizes="(max-width: 768px) 100vw, 40vw" />
+        <Image src={src} alt={alt} fill className="object-contain" sizes="(max-width: 768px) 100vw, 40vw" />
       </div>
     </div>
   );
 }
 
-function FullImage({ src, portrait }: { src: string; portrait?: boolean }) {
+function FullImage({ src, alt, portrait }: { src: string; alt: string; portrait?: boolean }) {
   return (
     <div className={`w-full md:w-1/2 ${portrait ? 'aspect-[2/3]' : 'aspect-square'} relative`}>
-      <Image src={src} alt="Kool Studio project" fill className="object-cover" sizes="(max-width: 768px) 100vw, 50vw" quality={90} />
+      <Image src={src} alt={alt} fill className="object-cover" sizes="(max-width: 768px) 100vw, 50vw" quality={90} />
     </div>
   );
 }
 
-function ReelVideo({ src, aspect = 'aspect-[9/16]' }: { src: string; aspect?: string }) {
+function ReelVideo({ src, alt, aspect = 'aspect-[9/16]' }: { src: string; alt: string; aspect?: string }) {
   return (
     <div className="w-full md:w-1/2 p-6 md:p-10 lg:p-14 xl:p-20 flex items-center">
       <video
@@ -71,14 +75,14 @@ function ReelVideo({ src, aspect = 'aspect-[9/16]' }: { src: string; aspect?: st
         muted
         loop
         playsInline
-        aria-label="Kool Studio project video"
+        aria-label={alt}
         className={`mx-auto w-full max-w-[360px] ${aspect} object-cover`}
       />
     </div>
   );
 }
 
-function SliderCell({ item }: { item: SliderData }) {
+function SliderCell({ item }: { item: SliderData & { beforeAlt: string; afterAlt: string } }) {
   return (
     <div className="w-full md:w-1/2">
       <BeforeAfterSlider
@@ -86,7 +90,10 @@ function SliderCell({ item }: { item: SliderData }) {
         afterSrc={item.afterSrc}
         beforeLabel={item.labels?.[0]}
         afterLabel={item.labels?.[1]}
+        beforeAlt={item.beforeAlt}
+        afterAlt={item.afterAlt}
         aspectClass={item.aspect ?? 'aspect-[2/3]'}
+        sizes="(max-width: 768px) 100vw, 50vw"
       />
     </div>
   );
@@ -94,12 +101,12 @@ function SliderCell({ item }: { item: SliderData }) {
 
 function FullSlot({ item, portrait }: { item: Item; portrait?: boolean }) {
   if (item.kind === 'slider') return <SliderCell item={item} />;
-  return item.kind === 'image' ? <FullImage src={item.src} portrait={portrait} /> : <ReelVideo src={item.src} aspect={item.aspect} />;
+  return item.kind === 'image' ? <FullImage src={item.src} alt={item.alt} portrait={portrait} /> : <ReelVideo src={item.src} alt={item.alt} aspect={item.aspect} />;
 }
 
 function PaddedSlot({ item, small }: { item: Item; small?: boolean }) {
   if (item.kind === 'slider') return <SliderCell item={item} />;
-  return item.kind === 'image' ? <PaddedImage src={item.src} small={small} /> : <ReelVideo src={item.src} aspect={item.aspect} />;
+  return item.kind === 'image' ? <PaddedImage src={item.src} alt={item.alt} small={small} /> : <ReelVideo src={item.src} alt={item.alt} aspect={item.aspect} />;
 }
 
 function TextBlock({ text, align = 'end' }: { text: string; align?: 'start' | 'end' }) {
@@ -114,7 +121,21 @@ function TextBlock({ text, align = 'end' }: { text: string; align?: 'start' | 'e
   );
 }
 
-export default function ProjectContent({ images, description, descriptionBlocks, fullWidthIndices, containedPairs, reverseLastRow, reel, slider, textRows, flipRowParity, portraitIndices, smallIndices }: ProjectContentProps) {
+export default function ProjectContent({ images, title, location, description, descriptionBlocks, fullWidthIndices, containedPairs, reverseLastRow, reel, slider, textRows, flipRowParity, portraitIndices, smallIndices }: ProjectContentProps) {
+  const locale = useLocale();
+
+  // Descriptive, localized alt text derived from real project data. Per-photo
+  // description is impossible, so photos use a truthful contextual pattern
+  // numbered from the hero (photograph 1) onward.
+  const isEn = locale === 'en';
+  const projectContext = isEn
+    ? `Interior of ${title}, ${location}`
+    : `Wnętrze projektu ${title}, ${location}`;
+  const photoAlt = (n: number) =>
+    isEn ? `${projectContext} — photograph ${n}` : `${projectContext} — fotografia ${n}`;
+  const reelAlt = isEn ? `Video of ${title}, ${location}` : `Film z projektu ${title}, ${location}`;
+  const sliderFrameAlt = (label?: string) => (label ? `${projectContext} — ${label}` : projectContext);
+
   if (images.length === 0 && !reel && !slider) return null;
 
   const texts = descriptionBlocks ?? [description];
@@ -128,13 +149,15 @@ export default function ProjectContent({ images, description, descriptionBlocks,
   }
   const textRowMap = new Map((textRows ?? []).map((r) => [r.row, r]));
 
-  const items: Item[] = images.map((src) => ({ kind: 'image', src }));
+  // `images` is the gallery (hero removed by the page), so gallery index i is
+  // the (i + 2)th photograph of the project (the hero is photograph 1).
+  const items: Item[] = images.map((src, i) => ({ kind: 'image', src, alt: photoAlt(i + 2) }));
   // Insert reel/slider items by ascending display index (each index is
   // measured in the final array, so inserting low-to-high keeps them aligned)
   const inserts: { index: number; item: Item }[] = [];
-  if (reel) inserts.push({ index: reel.index, item: { kind: 'reel', src: reel.src, aspect: reel.aspect } });
+  if (reel) inserts.push({ index: reel.index, item: { kind: 'reel', src: reel.src, aspect: reel.aspect, alt: reelAlt } });
   for (const s of slider ? (Array.isArray(slider) ? slider : [slider]) : []) {
-    inserts.push({ index: s.index, item: { kind: 'slider', beforeSrc: s.beforeSrc, afterSrc: s.afterSrc, labels: s.labels, aspect: s.aspect } });
+    inserts.push({ index: s.index, item: { kind: 'slider', beforeSrc: s.beforeSrc, afterSrc: s.afterSrc, labels: s.labels, aspect: s.aspect, beforeAlt: sliderFrameAlt(s.labels?.[0]), afterAlt: sliderFrameAlt(s.labels?.[1]) } });
   }
   inserts.sort((a, b) => a.index - b.index);
   for (const ins of inserts) {
@@ -154,7 +177,7 @@ export default function ProjectContent({ images, description, descriptionBlocks,
     // Full-width row
     if (fullWidthSet.has(itemIdx) && current.kind === 'image') {
       rows.push(
-        <ParallaxImage key={`row-${rowIdx}`} src={current.src} alt="Kool Studio project" sizes="100vw" quality={90} />
+        <ParallaxImage key={`row-${rowIdx}`} src={current.src} alt={current.alt} sizes="100vw" quality={90} />
       );
       itemIdx++;
       rowIdx++;
@@ -177,8 +200,11 @@ export default function ProjectContent({ images, description, descriptionBlocks,
             afterSrc={next.src}
             beforeLabel={labels?.[0]}
             afterLabel={labels?.[1]}
+            beforeAlt={sliderFrameAlt(labels?.[0])}
+            afterAlt={sliderFrameAlt(labels?.[1])}
             aspectClass={pairInfo.aspect}
             labelPosition="above"
+            sizes={pairInfo.scale ? `${Math.round(pairInfo.scale * 100)}vw` : '100vw'}
           />
         </div>
       );

--- a/components/ProjectServiceCta.tsx
+++ b/components/ProjectServiceCta.tsx
@@ -40,6 +40,10 @@ export default function ProjectServiceCta({ serviceKey, serviceHref }: ProjectSe
         <div className="mt-8 md:mt-10 flex flex-col gap-4 md:gap-5">
           <Link
             href="/kontakt#brief"
+            data-analytics="cta_click"
+            data-analytics-service={serviceKey === 'oferta' ? undefined : serviceKey}
+            data-analytics-position="project-cta"
+            data-analytics-cta-text={t('ctaButton')}
             className="inline-flex items-center gap-2 text-coral font-[700] uppercase tracking-[0.06em] hover:opacity-60 transition-opacity"
             style={{ fontSize: 'clamp(15px, 1.5vw, 20px)' }}
           >

--- a/components/ProjectServiceCta.tsx
+++ b/components/ProjectServiceCta.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { useTranslations } from 'next-intl';
+import { Link } from '@/i18n/navigation';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+import type { RelatedService } from '@/data/projects';
+
+const EASE: [number, number, number, number] = [0.22, 1, 0.36, 1];
+
+interface ProjectServiceCtaProps {
+  // Which service page to cross-link to, and its already-built href.
+  serviceKey: RelatedService;
+  serviceHref: string;
+}
+
+/* Closing block on a project detail page: a problem-specific brief CTA plus a
+   descriptive link to the matching service page (the case → service half of
+   the internal-linking contract). Anchors describe their destination. */
+export default function ProjectServiceCta({ serviceKey, serviceHref }: ProjectServiceCtaProps) {
+  const t = useTranslations('caseStudy');
+  const reduceMotion = useReducedMotion();
+
+  const fade = {
+    initial: { opacity: 0, y: reduceMotion ? 0 : 16 },
+    whileInView: { opacity: 1, y: 0 },
+    viewport: { once: true, amount: 0.2 },
+    transition: { duration: reduceMotion ? 0 : 0.7, ease: EASE },
+  };
+
+  return (
+    <section className="border-t border-coral/40 px-5 md:px-10 lg:px-12 py-14 md:py-20">
+      <motion.div {...fade} className="max-w-content mx-auto">
+        <h2
+          className="font-[700] text-dark uppercase leading-[1.08] max-w-[900px]"
+          style={{ fontSize: 'clamp(22px, 3vw, 40px)' }}
+        >
+          {t('ctaText')}
+        </h2>
+        <div className="mt-8 md:mt-10 flex flex-col gap-4 md:gap-5">
+          <Link
+            href="/kontakt#brief"
+            className="inline-flex items-center gap-2 text-coral font-[700] uppercase tracking-[0.06em] hover:opacity-60 transition-opacity"
+            style={{ fontSize: 'clamp(15px, 1.5vw, 20px)' }}
+          >
+            {t('ctaButton')} <span aria-hidden="true">→</span>
+          </Link>
+          <Link
+            href={serviceHref}
+            className="inline-flex items-center gap-2 text-dark font-[600] uppercase tracking-[0.06em] hover:text-coral transition-colors"
+            style={{ fontSize: 'clamp(13px, 1.2vw, 16px)' }}
+          >
+            {t(`serviceLinks.${serviceKey}`)} <span aria-hidden="true">→</span>
+          </Link>
+        </div>
+      </motion.div>
+    </section>
+  );
+}

--- a/components/ProjectServiceCta.tsx
+++ b/components/ProjectServiceCta.tsx
@@ -29,7 +29,7 @@ export default function ProjectServiceCta({ serviceKey, serviceHref }: ProjectSe
   };
 
   return (
-    <section className="border-t border-coral/40 px-5 md:px-10 lg:px-12 py-14 md:py-20">
+    <section className="border-t border-dark/10 px-5 md:px-10 lg:px-12 py-14 md:py-20">
       <motion.div {...fade} className="max-w-content mx-auto">
         <h2
           className="font-[700] text-dark uppercase leading-[1.08] max-w-[900px]"

--- a/components/analytics.test.ts
+++ b/components/analytics.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  denyAnalyticsConsent,
+  grantAnalyticsConsent,
+  pageTypeFromPath,
+  trackBriefMailtoFallback,
+  trackBriefStart,
+  trackBriefSubmit,
+  trackCaseEngaged,
+  trackCtaClick,
+  trackEmailClick,
+} from '@/lib/analytics';
+
+type GtagCall = unknown[];
+type WindowWithGtag = { gtag?: (...args: unknown[]) => void };
+
+function installGtag(): GtagCall[] {
+  const calls: GtagCall[] = [];
+  (window as unknown as WindowWithGtag).gtag = (...args: unknown[]) => {
+    calls.push(args);
+  };
+  return calls;
+}
+
+function removeGtag(): void {
+  delete (window as unknown as WindowWithGtag).gtag;
+}
+
+// The params object of the last dispatched event/consent call.
+function lastParams(calls: GtagCall[]): Record<string, unknown> {
+  const call = calls[calls.length - 1];
+  return call[2] as Record<string, unknown>;
+}
+
+afterEach(removeGtag);
+
+describe('analytics wrapper — inert when gtag is absent', () => {
+  it('no-ops and never throws with no gtag loaded', () => {
+    removeGtag();
+    expect(() => {
+      trackCtaClick({ page_type: 'service', cta_text: 'x', position: 'service-cta' });
+      trackBriefStart({ page_path: '/pl/kontakt' });
+      trackEmailClick({ page_type: 'contact', position: 'footer' });
+      trackCaseEngaged({ case_id: 'walecznych' });
+      grantAnalyticsConsent();
+      denyAnalyticsConsent();
+    }).not.toThrow();
+  });
+
+  it('brief helpers still return an event id when gtag is absent', () => {
+    removeGtag();
+    expect(typeof trackBriefSubmit()).toBe('string');
+    expect(trackBriefSubmit().length).toBeGreaterThan(7);
+    expect(typeof trackBriefMailtoFallback()).toBe('string');
+  });
+
+  it('never throws even if gtag itself throws', () => {
+    (window as unknown as WindowWithGtag).gtag = () => {
+      throw new Error('boom');
+    };
+    expect(() =>
+      trackCtaClick({ page_type: 'home', cta_text: 'x', position: 'hub' })
+    ).not.toThrow();
+    expect(() => grantAnalyticsConsent()).not.toThrow();
+  });
+});
+
+describe('analytics wrapper — event name + param shaping', () => {
+  it('cta_click sends exactly the allowed params, including service', () => {
+    const calls = installGtag();
+    trackCtaClick({
+      page_type: 'service',
+      service: 'projekt-mieszkania',
+      cta_text: 'Umów spotkanie',
+      position: 'service-cta',
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0]).toBe('event');
+    expect(calls[0][1]).toBe('cta_click');
+    expect(lastParams(calls)).toEqual({
+      page_type: 'service',
+      service: 'projekt-mieszkania',
+      cta_text: 'Umów spotkanie',
+      position: 'service-cta',
+    });
+  });
+
+  it('omits an absent optional service param entirely', () => {
+    const calls = installGtag();
+    trackCtaClick({ page_type: 'home', cta_text: 'x', position: 'hub' });
+    expect(Object.keys(lastParams(calls))).not.toContain('service');
+    expect(lastParams(calls)).toEqual({ page_type: 'home', cta_text: 'x', position: 'hub' });
+  });
+
+  it('email_click carries only page_type + position — never an address', () => {
+    const calls = installGtag();
+    trackEmailClick({ page_type: 'contact', position: 'footer' });
+    expect(calls[0][1]).toBe('email_click');
+    expect(Object.keys(lastParams(calls)).sort()).toEqual(['page_type', 'position']);
+    expect(JSON.stringify(lastParams(calls))).not.toContain('@');
+  });
+
+  it('case_engaged sends case_id and optional service', () => {
+    const calls = installGtag();
+    trackCaseEngaged({ case_id: 'walecznych', service: 'projekt-mieszkania' });
+    expect(calls[0][1]).toBe('case_engaged');
+    expect(lastParams(calls)).toEqual({
+      case_id: 'walecznych',
+      service: 'projekt-mieszkania',
+    });
+  });
+
+  it('brief_start carries a bare page_path only', () => {
+    const calls = installGtag();
+    trackBriefStart({ page_path: '/pl/kontakt' });
+    expect(calls[0][1]).toBe('brief_start');
+    expect(lastParams(calls)).toEqual({ page_path: '/pl/kontakt' });
+  });
+});
+
+describe('analytics wrapper — brief_submit event_id', () => {
+  it('generates a fresh, non-empty id per call', () => {
+    const calls = installGtag();
+    const first = trackBriefSubmit();
+    const second = trackBriefSubmit();
+
+    expect(first).not.toEqual(second);
+    expect(first.length).toBeGreaterThan(7);
+
+    // The returned id is exactly the one dispatched, and it is the only param
+    // when no service is supplied.
+    expect(calls[0][1]).toBe('brief_submit');
+    expect(lastParams([calls[0]])).toEqual({ event_id: first });
+    expect((calls[1][2] as Record<string, unknown>).event_id).toBe(second);
+  });
+
+  it('brief_mailto_fallback carries only a fresh event_id', () => {
+    const calls = installGtag();
+    const id = trackBriefMailtoFallback();
+    expect(calls[0][1]).toBe('brief_mailto_fallback');
+    expect(lastParams(calls)).toEqual({ event_id: id });
+  });
+});
+
+describe('analytics wrapper — consent + page_type', () => {
+  it('grant/deny push a Consent Mode v2 update for analytics_storage only', () => {
+    const calls = installGtag();
+    grantAnalyticsConsent();
+    expect(calls[0]).toEqual(['consent', 'update', { analytics_storage: 'granted' }]);
+    denyAnalyticsConsent();
+    expect(calls[1]).toEqual(['consent', 'update', { analytics_storage: 'denied' }]);
+  });
+
+  it('maps routes to coarse, non-PII page types', () => {
+    expect(pageTypeFromPath('/')).toBe('home');
+    expect(pageTypeFromPath('/kontakt')).toBe('contact');
+    expect(pageTypeFromPath('/studio')).toBe('studio');
+    expect(pageTypeFromPath('/oferta')).toBe('services');
+    expect(pageTypeFromPath('/oferta/projekt-mieszkania')).toBe('service');
+    expect(pageTypeFromPath('/projekty')).toBe('projects');
+    expect(pageTypeFromPath('/projekty/walecznych')).toBe('project');
+    // tolerant of a leading locale segment
+    expect(pageTypeFromPath('/en/projekty/walecznych')).toBe('project');
+    expect(pageTypeFromPath('/nieznane')).toBe('other');
+  });
+});

--- a/components/kontakt/BriefForm.tsx
+++ b/components/kontakt/BriefForm.tsx
@@ -4,6 +4,12 @@ import { useActionState, useEffect, useRef } from 'react';
 import { motion } from 'framer-motion';
 import { useTranslations } from 'next-intl';
 import { useReducedMotion } from '@/hooks/useReducedMotion';
+import {
+  analyticsEnabled,
+  trackBriefStart,
+  trackBriefSubmit,
+  trackBriefMailtoFallback,
+} from '@/lib/analytics';
 import { submitBrief } from '@/app/[locale]/kontakt/actions';
 import {
   initialBriefState,
@@ -41,6 +47,18 @@ export default function BriefForm() {
   const mountTime = useRef<number | null>(null);
   const resultRef = useRef<HTMLDivElement>(null);
   const formErrorRef = useRef<HTMLParagraphElement>(null);
+  // brief_start guard — first meaningful interaction, once per page view.
+  const briefStartedRef = useRef(false);
+
+  // Fire brief_start on the first real focus/input (honeypot + anti-spam field
+  // excluded). Inert unless GA4 is configured.
+  const handleBriefStart = (event: React.SyntheticEvent) => {
+    if (briefStartedRef.current || !analyticsEnabled) return;
+    const name = (event.target as HTMLElement & { name?: string }).name;
+    if (name === 'company' || name === 'ts') return;
+    briefStartedRef.current = true;
+    trackBriefStart({ page_path: window.location.pathname });
+  };
 
   const values = state.values;
   const errors = state.status === 'invalid' ? state.errors : undefined;
@@ -86,6 +104,20 @@ export default function BriefForm() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.submittedAt]);
 
+  // Analytics: report the terminal outcome exactly once per submission, keeping
+  // confirmed server delivery (brief_submit) and the mailto path
+  // (brief_mailto_fallback) as distinct events so they are never conflated.
+  // The helpers no-op when GA4 is not loaded and never carry any field value.
+  useEffect(() => {
+    if (!analyticsEnabled) return;
+    if (state.status === 'success') {
+      trackBriefSubmit();
+    } else if (state.status === 'fallback') {
+      trackBriefMailtoFallback();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.submittedAt]);
+
   const describedBy = (field: BriefField, hasHelp: boolean): string | undefined => {
     const ids: string[] = [];
     if (hasHelp) ids.push(`brief-${field}-help`);
@@ -119,6 +151,7 @@ export default function BriefForm() {
         {state.fallback && (
           <a
             href={state.fallback.mailtoHref}
+            data-analytics-skip
             className="inline-flex items-center gap-2 mt-5 mb-8 border border-dark px-6 py-3 min-h-[48px] font-[600] uppercase tracking-[0.06em] text-dark hover:bg-coral hover:border-coral hover:text-white transition-colors"
           >
             {t('status.fallbackButton')} <span aria-hidden="true">→</span>
@@ -157,6 +190,8 @@ export default function BriefForm() {
         id="brief-form"
         action={formAction}
         noValidate
+        onFocusCapture={handleBriefStart}
+        onInput={handleBriefStart}
         className="mt-10 md:mt-12"
       >
         {/* Honeypot: off-screen, hidden from assistive tech, out of tab order. */}

--- a/components/kontakt/BriefForm.tsx
+++ b/components/kontakt/BriefForm.tsx
@@ -1,0 +1,613 @@
+'use client';
+
+import { useActionState, useEffect, useRef } from 'react';
+import { motion } from 'framer-motion';
+import { useTranslations } from 'next-intl';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+import { submitBrief } from '@/app/[locale]/kontakt/actions';
+import {
+  initialBriefState,
+  type BriefFormState,
+} from '@/app/[locale]/kontakt/brief-state';
+import {
+  PROJECT_TYPES,
+  STAGES,
+  SCOPE_ITEMS,
+  BRIEF_FIELD_ORDER,
+  LIMITS,
+  type BriefField,
+  type NormalizedBrief,
+} from '@/lib/brief';
+
+const EASE: [number, number, number, number] = [0.22, 1, 0.36, 1];
+
+// Shared control styling: dark/muted borders, coral only as the focus accent.
+const CONTROL =
+  'w-full min-h-[48px] bg-transparent border border-dark/25 rounded-none px-4 py-3 text-dark text-[16px] leading-normal ' +
+  'placeholder:text-muted focus:outline-none focus:border-coral focus:ring-1 focus:ring-coral transition-colors';
+
+// Fields that carry a per-field error code (scope has no error path).
+const ERRORABLE_ORDER: BriefField[] = BRIEF_FIELD_ORDER.filter((f) => f !== 'scope');
+
+export default function BriefForm() {
+  const t = useTranslations('brief');
+  const reduceMotion = useReducedMotion();
+  const [state, formAction, isPending] = useActionState<BriefFormState, FormData>(
+    submitBrief,
+    initialBriefState
+  );
+
+  const tsRef = useRef<HTMLInputElement>(null);
+  const mountTime = useRef<number | null>(null);
+  const resultRef = useRef<HTMLDivElement>(null);
+  const formErrorRef = useRef<HTMLParagraphElement>(null);
+
+  const values = state.values;
+  const errors = state.status === 'invalid' ? state.errors : undefined;
+
+  // Keep the anti-spam timestamp populated on the client (empty during SSR so
+  // there is no hydration mismatch; Date.now() runs in the effect, not during
+  // render). Re-apply after each submit if React's form auto-reset cleared it;
+  // the original mount time is reused so elapsed only ever grows and never
+  // falsely blocks a genuine user.
+  useEffect(() => {
+    if (mountTime.current === null) mountTime.current = Date.now();
+    if (tsRef.current && !tsRef.current.value) {
+      tsRef.current.value = String(mountTime.current);
+    }
+  }, [state.submittedAt]);
+
+  // Post-submit side effects: move focus, open the mailto fallback.
+  useEffect(() => {
+    if (state.status === 'idle') return;
+
+    if (state.status === 'invalid' && state.errors) {
+      const first = ERRORABLE_ORDER.find((f) => state.errors?.[f]);
+      if (first) {
+        document.getElementById(`brief-${first}`)?.focus();
+        return;
+      }
+    }
+
+    if (state.status === 'error') {
+      formErrorRef.current?.focus();
+      return;
+    }
+
+    if (state.status === 'success' || state.status === 'fallback') {
+      resultRef.current?.focus();
+    }
+
+    if (state.status === 'fallback' && state.fallback) {
+      // Open the user's mail client with the prefilled brief. The manual
+      // button below is the reliable path if the browser blocks this.
+      window.location.href = state.fallback.mailtoHref;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.submittedAt]);
+
+  const describedBy = (field: BriefField, hasHelp: boolean): string | undefined => {
+    const ids: string[] = [];
+    if (hasHelp) ids.push(`brief-${field}-help`);
+    if (errors?.[field]) ids.push(`brief-${field}-error`);
+    return ids.length ? ids.join(' ') : undefined;
+  };
+
+  const errorText = (field: BriefField) => {
+    const code = errors?.[field];
+    return code ? t(`errors.${code}`) : null;
+  };
+
+  // --- Result panels (replace the form) ---------------------------------
+
+  if (state.status === 'success') {
+    return (
+      <ResultPanel refEl={resultRef}>
+        <ResultHeading>{t('status.successTitle')}</ResultHeading>
+        <p className="text-dark/80 mt-3 mb-8 text-[clamp(15px,1.4vw,18px)] leading-[1.55]">
+          {t('status.successNote')}
+        </p>
+        {state.submitted && <SubmittedSummary submitted={state.submitted} t={t} />}
+      </ResultPanel>
+    );
+  }
+
+  if (state.status === 'fallback') {
+    return (
+      <ResultPanel refEl={resultRef}>
+        <ResultHeading>{t('status.fallbackNote')}</ResultHeading>
+        {state.fallback && (
+          <a
+            href={state.fallback.mailtoHref}
+            className="inline-flex items-center gap-2 mt-5 mb-8 border border-dark px-6 py-3 min-h-[48px] font-[600] uppercase tracking-[0.06em] text-dark hover:bg-coral hover:border-coral hover:text-white transition-colors"
+          >
+            {t('status.fallbackButton')} <span aria-hidden="true">→</span>
+          </a>
+        )}
+        {state.submitted && <SubmittedSummary submitted={state.submitted} t={t} />}
+      </ResultPanel>
+    );
+  }
+
+  // --- The form ---------------------------------------------------------
+
+  const heading = (
+    <h2
+      className="text-dark font-[700] uppercase leading-tight"
+      style={{ fontSize: 'clamp(26px, 3.6vw, 44px)' }}
+    >
+      {t('heading')}
+    </h2>
+  );
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: reduceMotion ? 0 : 24 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.15 }}
+      transition={{ duration: 0.8, ease: EASE }}
+    >
+      {heading}
+      <p className="text-muted mt-4 max-w-[640px] text-[clamp(15px,1.4vw,18px)] leading-[1.55]">
+        {t('intro')}
+      </p>
+      <p className="text-muted mt-2 text-[14px]">{t('requiredHint')}</p>
+
+      <form
+        id="brief-form"
+        action={formAction}
+        noValidate
+        className="mt-10 md:mt-12"
+      >
+        {/* Honeypot: off-screen, hidden from assistive tech, out of tab order. */}
+        <div
+          aria-hidden="true"
+          className="absolute left-[-9999px] top-auto h-px w-px overflow-hidden"
+        >
+          <label htmlFor="brief-company">{t('honeypotLabel')}</label>
+          <input
+            id="brief-company"
+            type="text"
+            name="company"
+            tabIndex={-1}
+            autoComplete="off"
+            defaultValue=""
+          />
+        </div>
+        {/* Anti-spam render timestamp (populated on the client). */}
+        <input type="hidden" name="ts" ref={tsRef} />
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
+          {/* name */}
+          <Field
+            field="name"
+            label={t('fields.name.label')}
+            help={t('fields.name.help')}
+            required
+            error={errorText('name')}
+          >
+            <input
+              id="brief-name"
+              name="name"
+              type="text"
+              required
+              aria-required="true"
+              maxLength={LIMITS.name}
+              autoComplete="given-name"
+              defaultValue={values?.name ?? ''}
+              aria-invalid={errors?.name ? true : undefined}
+              aria-describedby={describedBy('name', true)}
+              className={CONTROL}
+            />
+          </Field>
+
+          {/* email */}
+          <Field
+            field="email"
+            label={t('fields.email.label')}
+            help={t('fields.email.help')}
+            required
+            error={errorText('email')}
+          >
+            <input
+              id="brief-email"
+              name="email"
+              type="email"
+              required
+              aria-required="true"
+              inputMode="email"
+              maxLength={LIMITS.email}
+              autoComplete="email"
+              defaultValue={values?.email ?? ''}
+              aria-invalid={errors?.email ? true : undefined}
+              aria-describedby={describedBy('email', true)}
+              className={CONTROL}
+            />
+          </Field>
+
+          {/* projectType */}
+          <Field
+            field="projectType"
+            label={t('fields.projectType.label')}
+            required
+            error={errorText('projectType')}
+          >
+            <select
+              id="brief-projectType"
+              name="projectType"
+              required
+              aria-required="true"
+              defaultValue={values?.projectType ?? ''}
+              aria-invalid={errors?.projectType ? true : undefined}
+              aria-describedby={describedBy('projectType', false)}
+              className={CONTROL}
+            >
+              <option value="">{t('fields.projectType.placeholder')}</option>
+              {PROJECT_TYPES.map((key) => (
+                <option key={key} value={key}>
+                  {t(`projectTypeOptions.${key}`)}
+                </option>
+              ))}
+            </select>
+          </Field>
+
+          {/* location */}
+          <Field
+            field="location"
+            label={t('fields.location.label')}
+            help={t('fields.location.help')}
+            error={errorText('location')}
+          >
+            <input
+              id="brief-location"
+              name="location"
+              type="text"
+              maxLength={LIMITS.location}
+              placeholder={t('fields.location.placeholder')}
+              defaultValue={values?.location ?? ''}
+              aria-invalid={errors?.location ? true : undefined}
+              aria-describedby={describedBy('location', true)}
+              className={CONTROL}
+            />
+          </Field>
+
+          {/* stage */}
+          <Field
+            field="stage"
+            label={t('fields.stage.label')}
+            error={errorText('stage')}
+          >
+            <select
+              id="brief-stage"
+              name="stage"
+              defaultValue={values?.stage ?? ''}
+              aria-invalid={errors?.stage ? true : undefined}
+              aria-describedby={describedBy('stage', false)}
+              className={CONTROL}
+            >
+              <option value="">{t('fields.stage.placeholder')}</option>
+              {STAGES.map((key) => (
+                <option key={key} value={key}>
+                  {t(`stageOptions.${key}`)}
+                </option>
+              ))}
+            </select>
+          </Field>
+
+          {/* area */}
+          <Field
+            field="area"
+            label={t('fields.area.label')}
+            error={errorText('area')}
+          >
+            <input
+              id="brief-area"
+              name="area"
+              type="text"
+              inputMode="numeric"
+              maxLength={LIMITS.area}
+              placeholder={t('fields.area.placeholder')}
+              defaultValue={values?.area ?? ''}
+              aria-invalid={errors?.area ? true : undefined}
+              aria-describedby={describedBy('area', false)}
+              className={CONTROL}
+            />
+          </Field>
+
+          {/* startDate */}
+          <Field
+            field="startDate"
+            label={t('fields.startDate.label')}
+            error={errorText('startDate')}
+          >
+            <input
+              id="brief-startDate"
+              name="startDate"
+              type="text"
+              maxLength={LIMITS.startDate}
+              placeholder={t('fields.startDate.placeholder')}
+              defaultValue={values?.startDate ?? ''}
+              aria-invalid={errors?.startDate ? true : undefined}
+              aria-describedby={describedBy('startDate', false)}
+              className={CONTROL}
+            />
+          </Field>
+
+          {/* completionDate */}
+          <Field
+            field="completionDate"
+            label={t('fields.completionDate.label')}
+            error={errorText('completionDate')}
+          >
+            <input
+              id="brief-completionDate"
+              name="completionDate"
+              type="text"
+              maxLength={LIMITS.completionDate}
+              placeholder={t('fields.completionDate.placeholder')}
+              defaultValue={values?.completionDate ?? ''}
+              aria-invalid={errors?.completionDate ? true : undefined}
+              aria-describedby={describedBy('completionDate', false)}
+              className={CONTROL}
+            />
+          </Field>
+
+          {/* scope — checkbox group */}
+          <fieldset
+            className="md:col-span-2 border-0 p-0 m-0"
+            aria-describedby="brief-scope-help"
+          >
+            <legend className="block text-dark font-[500] text-[13px] uppercase tracking-[0.08em] mb-1">
+              {t('fields.scope.label')}
+            </legend>
+            <p id="brief-scope-help" className="text-muted text-[13px] mb-3">
+              {t('fields.scope.help')}
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-3">
+              {SCOPE_ITEMS.map((key) => (
+                <label
+                  key={key}
+                  htmlFor={`brief-scope-${key}`}
+                  className="flex items-center gap-3 min-h-[44px] cursor-pointer text-dark text-[15px]"
+                >
+                  <input
+                    id={`brief-scope-${key}`}
+                    type="checkbox"
+                    name="scope"
+                    value={key}
+                    defaultChecked={values?.scope?.includes(key) ?? false}
+                    className="h-5 w-5 shrink-0 accent-coral"
+                  />
+                  <span>{t(`scopeOptions.${key}`)}</span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          {/* budget */}
+          <Field
+            field="budget"
+            className="md:col-span-2"
+            label={t('fields.budget.label')}
+            help={t('fields.budget.help')}
+            error={errorText('budget')}
+          >
+            <input
+              id="brief-budget"
+              name="budget"
+              type="text"
+              maxLength={LIMITS.budget}
+              defaultValue={values?.budget ?? ''}
+              aria-invalid={errors?.budget ? true : undefined}
+              aria-describedby={describedBy('budget', true)}
+              className={CONTROL}
+            />
+          </Field>
+
+          {/* priorities */}
+          <Field
+            field="priorities"
+            className="md:col-span-2"
+            label={t('fields.priorities.label')}
+            help={t('fields.priorities.help')}
+            error={errorText('priorities')}
+          >
+            <textarea
+              id="brief-priorities"
+              name="priorities"
+              rows={4}
+              maxLength={LIMITS.priorities}
+              defaultValue={values?.priorities ?? ''}
+              aria-invalid={errors?.priorities ? true : undefined}
+              aria-describedby={describedBy('priorities', true)}
+              className={`${CONTROL} resize-y`}
+            />
+          </Field>
+
+          {/* plansUrl */}
+          <Field
+            field="plansUrl"
+            className="md:col-span-2"
+            label={t('fields.plansUrl.label')}
+            help={t('fields.plansUrl.help')}
+            error={errorText('plansUrl')}
+          >
+            <input
+              id="brief-plansUrl"
+              name="plansUrl"
+              type="url"
+              inputMode="url"
+              maxLength={LIMITS.plansUrl}
+              placeholder={t('fields.plansUrl.placeholder')}
+              defaultValue={values?.plansUrl ?? ''}
+              aria-invalid={errors?.plansUrl ? true : undefined}
+              aria-describedby={describedBy('plansUrl', true)}
+              className={CONTROL}
+            />
+          </Field>
+        </div>
+
+        {/* Live status region: pending / invalid summary / generic error. */}
+        <div aria-live="polite" aria-atomic="true" className="mt-8">
+          {isPending && <p className="text-muted text-[15px]">{t('status.sending')}</p>}
+          {!isPending && state.status === 'invalid' && (
+            <p className="text-coral text-[15px] font-[500]">{t('errors.summary')}</p>
+          )}
+          {!isPending && state.status === 'error' && (
+            <p
+              ref={formErrorRef}
+              tabIndex={-1}
+              className="text-coral text-[15px] font-[500] outline-none"
+            >
+              {t('status.generic')}
+            </p>
+          )}
+        </div>
+
+        <div className="mt-6 flex flex-col items-start gap-4">
+          <button
+            id="brief-submit"
+            type="submit"
+            disabled={isPending}
+            data-brief-submit
+            className="inline-flex items-center gap-2 border border-dark px-8 py-3 min-h-[48px] font-[600] uppercase tracking-[0.06em] text-dark hover:bg-coral hover:border-coral hover:text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isPending ? t('sending') : t('submit')}
+            {!isPending && <span aria-hidden="true">→</span>}
+          </button>
+          <p className="text-muted text-[13px] leading-[1.5] max-w-[560px]">
+            {t('privacy')}
+          </p>
+        </div>
+      </form>
+    </motion.div>
+  );
+}
+
+// --- Internal presentational helpers -----------------------------------
+
+interface FieldProps {
+  field: BriefField;
+  label: string;
+  help?: string;
+  required?: boolean;
+  className?: string;
+  error?: string | null;
+  children: React.ReactNode;
+}
+
+// Label above control, help + error programmatically associated. The control
+// itself (passed as children) carries id / aria-describedby / aria-invalid.
+function Field({
+  field,
+  label,
+  help,
+  required = false,
+  className = '',
+  error,
+  children,
+}: FieldProps) {
+  return (
+    <div className={className}>
+      <label
+        htmlFor={`brief-${field}`}
+        className="block text-dark font-[500] text-[13px] uppercase tracking-[0.08em] mb-1"
+      >
+        {label}
+        {required && (
+          <>
+            <span className="text-coral" aria-hidden="true">
+              {' '}
+              *
+            </span>
+            <span className="sr-only"> (wymagane)</span>
+          </>
+        )}
+      </label>
+      {help && (
+        <p id={`brief-${field}-help`} className="text-muted text-[13px] mb-2">
+          {help}
+        </p>
+      )}
+      {children}
+      {error && (
+        <p id={`brief-${field}-error`} className="text-coral text-[13px] mt-1 font-[500]">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ResultPanel({
+  refEl,
+  children,
+}: {
+  refEl: React.RefObject<HTMLDivElement | null>;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      ref={refEl}
+      tabIndex={-1}
+      role="status"
+      aria-live="polite"
+      className="outline-none"
+    >
+      {children}
+    </div>
+  );
+}
+
+function ResultHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h2
+      className="text-dark font-[700] uppercase leading-tight"
+      style={{ fontSize: 'clamp(22px, 3vw, 36px)' }}
+    >
+      {children}
+    </h2>
+  );
+}
+
+// Read-back of the submitted brief (success + fallback). Localises option keys
+// and skips empty fields.
+function SubmittedSummary({
+  submitted,
+  t,
+}: {
+  submitted: NormalizedBrief;
+  t: ReturnType<typeof useTranslations>;
+}) {
+  const rows = BRIEF_FIELD_ORDER.map((field) => {
+    let value = '';
+    if (field === 'projectType') {
+      value = submitted.projectType ? t(`projectTypeOptions.${submitted.projectType}`) : '';
+    } else if (field === 'stage') {
+      value = submitted.stage ? t(`stageOptions.${submitted.stage}`) : '';
+    } else if (field === 'scope') {
+      value = submitted.scope.map((k) => t(`scopeOptions.${k}`)).join(', ');
+    } else {
+      value = submitted[field] as string;
+    }
+    return { field, value };
+  }).filter((row) => row.value.length > 0);
+
+  if (rows.length === 0) return null;
+
+  return (
+    <div className="border-t border-dark/15 pt-6">
+      <h3 className="text-dark font-[600] text-[13px] uppercase tracking-[0.08em] mb-4">
+        {t('status.submittedHeading')}
+      </h3>
+      <dl className="grid grid-cols-1 sm:grid-cols-[minmax(0,220px)_1fr] gap-x-6 gap-y-3">
+        {rows.map(({ field, value }) => (
+          <div key={field} className="contents">
+            <dt className="text-muted text-[14px]">{t(`fields.${field}.label`)}</dt>
+            <dd className="text-dark text-[15px] break-words">{value}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}

--- a/components/oferta/FaqAccordion.tsx
+++ b/components/oferta/FaqAccordion.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useId, useState } from 'react';
+import { Link } from '@/i18n/navigation';
+import type { ServiceFaq } from '@/data/services';
+
+interface FaqAccordionProps {
+  items: ServiceFaq[];
+}
+
+// FAQ link: an on-page anchor ('#zakres') renders as a plain <a> so it isn't
+// locale-prefixed; a route ('/kontakt', '/projekty/<slug>') uses the
+// locale-aware Link.
+function FaqLink({ link }: { link: ServiceFaq['link'] }) {
+  const className =
+    'inline-flex items-center gap-1 text-coral font-[600] uppercase tracking-[0.06em] hover:opacity-60 transition-opacity';
+  if (link.href.startsWith('#')) {
+    return (
+      <a href={link.href} className={className}>
+        {link.label} <span aria-hidden="true">→</span>
+      </a>
+    );
+  }
+  return (
+    <Link href={link.href} className={className}>
+      {link.label} <span aria-hidden="true">→</span>
+    </Link>
+  );
+}
+
+// Accessible disclosure list: each question is a real <button> carrying
+// aria-expanded + aria-controls, keyboard-operable natively. The answer panel
+// is always rendered in the HTML (crawlable) and toggled with the `hidden`
+// attribute — collapsed content stays in the server markup but leaves the
+// accessibility tree. No conditional mounting.
+export default function FaqAccordion({ items }: FaqAccordionProps) {
+  const baseId = useId();
+  const [open, setOpen] = useState<Record<number, boolean>>({});
+
+  return (
+    <div className="border-t border-dark/15">
+      {items.map((item, i) => {
+        const isOpen = Boolean(open[i]);
+        const buttonId = `${baseId}-faq-${i}-button`;
+        const panelId = `${baseId}-faq-${i}-panel`;
+        return (
+          <div key={i} className="border-b border-dark/15">
+            <h3 className="m-0">
+              <button
+                id={buttonId}
+                type="button"
+                aria-expanded={isOpen}
+                aria-controls={panelId}
+                onClick={() => setOpen((prev) => ({ ...prev, [i]: !prev[i] }))}
+                className="flex w-full items-center justify-between gap-6 py-6 md:py-7 text-left group"
+              >
+                <span
+                  className="font-[600] text-dark uppercase leading-[1.25]"
+                  style={{ fontSize: 'clamp(16px, 1.8vw, 24px)' }}
+                >
+                  {item.q}
+                </span>
+                <span
+                  aria-hidden="true"
+                  className="shrink-0 text-coral text-[26px] md:text-[30px] leading-none font-[300] transition-transform duration-300"
+                  style={{ transform: isOpen ? 'rotate(45deg)' : 'rotate(0deg)' }}
+                >
+                  +
+                </span>
+              </button>
+            </h3>
+            <div
+              id={panelId}
+              role="region"
+              aria-labelledby={buttonId}
+              hidden={!isOpen}
+              className="pb-7 md:pb-9 pr-8 md:pr-16"
+            >
+              <p
+                className="text-dark/80 font-[400] leading-[1.55] max-w-[900px] mb-5"
+                style={{ fontSize: 'clamp(15px, 1.4vw, 19px)' }}
+              >
+                {item.a}
+              </p>
+              <FaqLink link={item.link} />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/oferta/ServiceLandingPage.tsx
+++ b/components/oferta/ServiceLandingPage.tsx
@@ -27,6 +27,8 @@ export type ProofCard = {
 
 interface ServiceLandingPageProps {
   line: ServiceLine;
+  // Service page slug, used only as the non-PII `service` analytics dimension.
+  serviceSlug: string;
   heroName: string;
   heroLead: string;
   heroImage: string;
@@ -61,6 +63,7 @@ function SectionHeading({ text }: { text: string }) {
 
 export default function ServiceLandingPage({
   line,
+  serviceSlug,
   heroName,
   heroLead,
   heroImage,
@@ -266,6 +269,10 @@ export default function ServiceLandingPage({
                 </h2>
                 <Link
                   href="/kontakt"
+                  data-analytics="cta_click"
+                  data-analytics-service={serviceSlug}
+                  data-analytics-position="service-cta"
+                  data-analytics-cta-text={t('cta.button')}
                   className="inline-flex items-center gap-2 text-coral font-[700] uppercase tracking-[0.06em] hover:opacity-60 transition-opacity"
                   style={{ fontSize: 'clamp(16px, 1.8vw, 24px)' }}
                 >

--- a/components/oferta/ServiceLandingPage.tsx
+++ b/components/oferta/ServiceLandingPage.tsx
@@ -1,0 +1,283 @@
+'use client';
+
+import Image from 'next/image';
+import { useLocale, useTranslations } from 'next-intl';
+import { motion } from 'framer-motion';
+import { Link } from '@/i18n/navigation';
+import Navbar from '@/components/Navbar';
+import FooterBanner from '@/components/FooterBanner';
+import ProjectHero from '@/components/ProjectHero';
+import ColumnImage from '@/components/ColumnImage';
+import RevealHeading from '@/components/RevealHeading';
+import Breadcrumbs, { type Crumb } from '@/components/Breadcrumbs';
+import FaqAccordion from '@/components/oferta/FaqAccordion';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+import type { ServiceFaq, ServiceLine } from '@/data/services';
+
+const EASE: [number, number, number, number] = [0.22, 1, 0.36, 1];
+
+export type ProofCard = {
+  slug: string;
+  title: string;
+  location: string;
+  area: string;
+  year: number;
+  thumbnail: string;
+};
+
+interface ServiceLandingPageProps {
+  line: ServiceLine;
+  heroName: string;
+  heroLead: string;
+  heroImage: string;
+  heroImageAlt: string;
+  crumbs: Crumb[];
+  situations: string[];
+  proof: ProofCard[];
+  proofAngles: string[];
+  faqs: ServiceFaq[];
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <span
+      className="font-[600] uppercase text-coral tracking-[0.14em] mb-4 md:mb-5 block"
+      style={{ fontSize: 'clamp(12px, 1.1vw, 14px)' }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function SectionHeading({ text }: { text: string }) {
+  return (
+    <RevealHeading
+      text={text}
+      className="font-[700] text-dark uppercase mb-8 md:mb-12 leading-[1.04]"
+      style={{ fontSize: 'clamp(26px, 3.6vw, 52px)' }}
+    />
+  );
+}
+
+export default function ServiceLandingPage({
+  line,
+  heroName,
+  heroLead,
+  heroImage,
+  heroImageAlt,
+  crumbs,
+  situations,
+  proof,
+  proofAngles,
+  faqs,
+}: ServiceLandingPageProps) {
+  const t = useTranslations('services');
+  const tOferta = useTranslations('oferta');
+  const locale = useLocale();
+  const reduceMotion = useReducedMotion();
+
+  const scopeItems = tOferta.raw(`${line}.scopeItems`) as string[];
+  const processSteps = tOferta.raw('process.steps') as string[];
+
+  const fade = {
+    initial: { opacity: 0, y: reduceMotion ? 0 : 16 },
+    whileInView: { opacity: 1, y: 0 },
+    viewport: { once: true, amount: 0.2 },
+    transition: { duration: reduceMotion ? 0 : 0.7, ease: EASE },
+  };
+
+  return (
+    <>
+      <ProjectHero src={heroImage} alt={heroImageAlt} />
+      <Navbar />
+      <main>
+        {/* Content scrolls over the fixed hero image */}
+        <div className="relative z-10 bg-beige">
+          <div className="px-5 pt-10 md:px-10 md:pt-14 lg:px-12">
+            <Breadcrumbs items={crumbs} />
+          </div>
+
+          {/* Hero text: service name + who it's for + outcome */}
+          <section className="px-5 md:px-10 lg:px-[68px] pt-10 md:pt-14 pb-14 md:pb-20">
+            <div className="max-w-[1400px] mx-auto">
+              <RevealHeading
+                as="h1"
+                text={heroName}
+                className="font-[700] text-dark uppercase mb-6 md:mb-8 leading-[1.02]"
+                style={{ fontSize: 'clamp(34px, 5.4vw, 76px)' }}
+              />
+              <p
+                className="text-dark/80 leading-[1.5] max-w-[1080px] font-[400]"
+                style={{ fontSize: 'clamp(16px, 1.6vw, 22px)' }}
+              >
+                {heroLead}
+              </p>
+            </div>
+          </section>
+
+          {/* Recognition — situations grounded in the published scope */}
+          <section id="kiedy-warto" className="px-5 md:px-10 lg:px-[68px] py-14 md:py-20 border-t border-coral/40">
+            <div className="max-w-[1400px] mx-auto">
+              <SectionLabel>{t('sections.recognition')}</SectionLabel>
+              <SectionHeading text={t('sections.recognition')} />
+              <ul className="border-t border-dark/15">
+                {situations.map((situation, i) => (
+                  <motion.li
+                    key={i}
+                    {...fade}
+                    transition={{ ...fade.transition, delay: reduceMotion ? 0 : i * 0.04 }}
+                    className="flex items-start gap-5 md:gap-8 border-b border-dark/15 py-6 md:py-7"
+                  >
+                    <span
+                      className="text-coral font-[700] tabular-nums shrink-0 leading-[1.3]"
+                      style={{ fontSize: 'clamp(15px, 1.5vw, 20px)' }}
+                    >
+                      {String(i + 1).padStart(2, '0')}
+                    </span>
+                    <span
+                      className="text-dark font-[400] leading-[1.45] max-w-[1000px]"
+                      style={{ fontSize: 'clamp(16px, 1.6vw, 22px)' }}
+                    >
+                      {situation}
+                    </span>
+                  </motion.li>
+                ))}
+              </ul>
+            </div>
+          </section>
+
+          {/* Scope — the exact published scope list for this service line */}
+          <section id="zakres" className="px-5 md:px-10 lg:px-[68px] py-14 md:py-20 border-t border-coral/40">
+            <div className="max-w-[1400px] mx-auto">
+              <SectionLabel>{t('sections.scope')}</SectionLabel>
+              <SectionHeading text={t('sections.scope')} />
+              <ul className="grid grid-cols-1 md:grid-cols-2 gap-x-12 lg:gap-x-20 gap-y-3.5 md:gap-y-[18px]">
+                {scopeItems.map((item, i) => (
+                  <li
+                    key={i}
+                    className="text-dark font-[400] leading-[1.4] flex items-start gap-3"
+                    style={{ fontSize: 'clamp(15px, 1.5vw, 20px)' }}
+                  >
+                    <span className="mt-[0.6em] w-1.5 h-1.5 bg-dark rounded-full flex-shrink-0" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </section>
+
+          {/* Process — the published 7 steps */}
+          <section id="proces" className="px-5 md:px-10 lg:px-[68px] py-14 md:py-20 border-t border-coral/40">
+            <div className="max-w-[1400px] mx-auto">
+              <SectionLabel>{t('sections.process')}</SectionLabel>
+              <SectionHeading text={t('sections.process')} />
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-0 items-stretch">
+                <ColumnImage
+                  src="/images/oferta/KOOL_oferta_finish_small.webp"
+                  alt={tOferta('processImageAlt')}
+                  width="w-[74%] md:w-[64%]"
+                  className="md:pr-8 lg:pr-12"
+                  sizes="(min-width: 768px) 32vw, 74vw"
+                />
+                <div className="flex flex-col justify-center md:pl-8 lg:pl-12">
+                  <ol className="space-y-6 md:space-y-8">
+                    {processSteps.map((step, i) => (
+                      <li
+                        key={i}
+                        className="flex items-start gap-3 md:gap-4 leading-[1.4]"
+                        style={{ fontSize: 'clamp(15px, 1.5vw, 20px)' }}
+                      >
+                        <span className="text-coral font-[700] tabular-nums">
+                          {String(i + 1).padStart(2, '0')}
+                        </span>
+                        <span className="text-dark font-[400]">{step}</span>
+                      </li>
+                    ))}
+                  </ol>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          {/* Proof — relevant projects with published facts */}
+          <section id="realizacje" className="px-5 md:px-10 lg:px-[68px] py-14 md:py-20 border-t border-coral/40">
+            <div className="max-w-[1400px] mx-auto">
+              <SectionLabel>{t('sections.proof')}</SectionLabel>
+              <SectionHeading text={t('sections.proof')} />
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-12 md:gap-y-16">
+                {proof.map((p, i) => {
+                  const thumbAlt =
+                    locale === 'en'
+                      ? `Interior of ${p.title}, ${p.location}`
+                      : `Wnętrze projektu ${p.title}, ${p.location}`;
+                  return (
+                    <Link key={p.slug} href={`/projekty/${p.slug}`} className="group block">
+                      <div className="overflow-hidden">
+                        <div className="relative aspect-square">
+                          <Image
+                            src={p.thumbnail}
+                            alt={thumbAlt}
+                            fill
+                            className="object-cover transition-transform duration-[600ms] group-hover:scale-[1.04]"
+                            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                          />
+                        </div>
+                      </div>
+                      <p className="mt-3 text-[14px] md:text-[15px] font-[600] text-dark uppercase">
+                        {p.title} / {p.location}
+                      </p>
+                      <p className="mt-1 text-muted uppercase tracking-[0.1em] text-[12px] md:text-[13px]">
+                        {p.area} · {p.year}
+                      </p>
+                      <p
+                        className="mt-3 text-dark/80 leading-[1.45]"
+                        style={{ fontSize: 'clamp(14px, 1.3vw, 17px)' }}
+                      >
+                        {proofAngles[i]}
+                      </p>
+                      <span className="mt-3 inline-flex items-center gap-1 text-coral font-[600] uppercase tracking-[0.06em] text-[13px] group-hover:opacity-60 transition-opacity">
+                        {t('viewProject')} <span aria-hidden="true">→</span>
+                      </span>
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
+          </section>
+
+          {/* FAQ — accessible accordion, answers grounded in published facts */}
+          <section id="faq" className="px-5 md:px-10 lg:px-[68px] py-14 md:py-20 border-t border-coral/40">
+            <div className="max-w-[1400px] mx-auto">
+              <SectionLabel>{t('sections.faq')}</SectionLabel>
+              <SectionHeading text={t('sections.faq')} />
+              <FaqAccordion items={faqs} />
+            </div>
+          </section>
+
+          {/* CTA — one dominant call to action */}
+          <section className="px-5 md:px-10 lg:px-[68px] pt-14 md:pt-20 pb-6 md:pb-10 border-t border-coral/40">
+            <div className="max-w-[1400px] mx-auto">
+              <motion.div {...fade}>
+                <h2
+                  className="font-[700] text-dark uppercase leading-[1.04] mb-8 md:mb-10 max-w-[1100px]"
+                  style={{ fontSize: 'clamp(30px, 4.6vw, 64px)' }}
+                >
+                  {t('cta.heading')}
+                </h2>
+                <Link
+                  href="/kontakt"
+                  className="inline-flex items-center gap-2 text-coral font-[700] uppercase tracking-[0.06em] hover:opacity-60 transition-opacity"
+                  style={{ fontSize: 'clamp(16px, 1.8vw, 24px)' }}
+                >
+                  {t('cta.button')} <span aria-hidden="true">→</span>
+                </Link>
+              </motion.div>
+            </div>
+          </section>
+
+          <FooterBanner showMarquee={false} />
+        </div>
+      </main>
+    </>
+  );
+}

--- a/components/oferta/ServiceLandingPage.tsx
+++ b/components/oferta/ServiceLandingPage.tsx
@@ -40,17 +40,6 @@ interface ServiceLandingPageProps {
   faqs: ServiceFaq[];
 }
 
-function SectionLabel({ children }: { children: React.ReactNode }) {
-  return (
-    <span
-      className="font-[600] uppercase text-coral tracking-[0.14em] mb-4 md:mb-5 block"
-      style={{ fontSize: 'clamp(12px, 1.1vw, 14px)' }}
-    >
-      {children}
-    </span>
-  );
-}
-
 function SectionHeading({ text }: { text: string }) {
   return (
     <RevealHeading
@@ -121,7 +110,6 @@ export default function ServiceLandingPage({
           {/* Recognition — situations grounded in the published scope */}
           <section id="kiedy-warto" className="px-5 md:px-10 lg:px-[68px] py-14 md:py-20 border-t border-coral/40">
             <div className="max-w-[1400px] mx-auto">
-              <SectionLabel>{t('sections.recognition')}</SectionLabel>
               <SectionHeading text={t('sections.recognition')} />
               <ul className="border-t border-dark/15">
                 {situations.map((situation, i) => (
@@ -152,7 +140,6 @@ export default function ServiceLandingPage({
           {/* Scope — the exact published scope list for this service line */}
           <section id="zakres" className="px-5 md:px-10 lg:px-[68px] py-14 md:py-20 border-t border-coral/40">
             <div className="max-w-[1400px] mx-auto">
-              <SectionLabel>{t('sections.scope')}</SectionLabel>
               <SectionHeading text={t('sections.scope')} />
               <ul className="grid grid-cols-1 md:grid-cols-2 gap-x-12 lg:gap-x-20 gap-y-3.5 md:gap-y-[18px]">
                 {scopeItems.map((item, i) => (
@@ -172,7 +159,6 @@ export default function ServiceLandingPage({
           {/* Process — the published 7 steps */}
           <section id="proces" className="px-5 md:px-10 lg:px-[68px] py-14 md:py-20 border-t border-coral/40">
             <div className="max-w-[1400px] mx-auto">
-              <SectionLabel>{t('sections.process')}</SectionLabel>
               <SectionHeading text={t('sections.process')} />
               <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-0 items-stretch">
                 <ColumnImage
@@ -205,7 +191,6 @@ export default function ServiceLandingPage({
           {/* Proof — relevant projects with published facts */}
           <section id="realizacje" className="px-5 md:px-10 lg:px-[68px] py-14 md:py-20 border-t border-coral/40">
             <div className="max-w-[1400px] mx-auto">
-              <SectionLabel>{t('sections.proof')}</SectionLabel>
               <SectionHeading text={t('sections.proof')} />
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-12 md:gap-y-16">
                 {proof.map((p, i) => {
@@ -251,7 +236,6 @@ export default function ServiceLandingPage({
           {/* FAQ — accessible accordion, answers grounded in published facts */}
           <section id="faq" className="px-5 md:px-10 lg:px-[68px] py-14 md:py-20 border-t border-coral/40">
             <div className="max-w-[1400px] mx-auto">
-              <SectionLabel>{t('sections.faq')}</SectionLabel>
               <SectionHeading text={t('sections.faq')} />
               <FaqAccordion items={faqs} />
             </div>

--- a/components/oferta/ServicesHubLinks.tsx
+++ b/components/oferta/ServicesHubLinks.tsx
@@ -39,6 +39,10 @@ export default function ServicesHubLinks() {
             >
               <Link
                 href={`/oferta/${service.slug}`}
+                data-analytics="cta_click"
+                data-analytics-service={service.slug}
+                data-analytics-position="hub"
+                data-analytics-cta-text={service.heroName}
                 className="group flex flex-col md:flex-row md:items-center md:justify-between gap-3 md:gap-10 py-8 md:py-10"
               >
                 <span className="md:flex-1">

--- a/components/oferta/ServicesHubLinks.tsx
+++ b/components/oferta/ServicesHubLinks.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useLocale, useTranslations } from 'next-intl';
+import { motion } from 'framer-motion';
+import { Link } from '@/i18n/navigation';
+import { localizeService, services } from '@/data/services';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+
+const EASE: [number, number, number, number] = [0.22, 1, 0.36, 1];
+
+// Server-rendered, always-mounted links block on the services hub: each
+// subpage is reachable with a descriptive anchor (the service name), so the
+// three landing pages are crawlable from /oferta.
+export default function ServicesHubLinks() {
+  const t = useTranslations('services');
+  const locale = useLocale();
+  const reduceMotion = useReducedMotion();
+
+  const items = services.map((service) => localizeService(service, locale));
+
+  return (
+    <section className="px-5 md:px-10 lg:px-[68px] py-16 md:py-24 border-t border-coral/40">
+      <div className="max-w-[1400px] mx-auto">
+        <span
+          className="font-[600] uppercase text-coral tracking-[0.14em] mb-8 md:mb-12 block"
+          style={{ fontSize: 'clamp(12px, 1.1vw, 14px)' }}
+        >
+          {t('hubHeading')}
+        </span>
+        <ul className="border-t border-dark/15">
+          {items.map((service, i) => (
+            <motion.li
+              key={service.slug}
+              initial={{ opacity: 0, y: reduceMotion ? 0 : 16 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, amount: 0.2 }}
+              transition={{ duration: reduceMotion ? 0 : 0.6, ease: EASE, delay: reduceMotion ? 0 : i * 0.06 }}
+              className="border-b border-dark/15"
+            >
+              <Link
+                href={`/oferta/${service.slug}`}
+                className="group flex flex-col md:flex-row md:items-center md:justify-between gap-3 md:gap-10 py-8 md:py-10"
+              >
+                <span className="md:flex-1">
+                  <span
+                    className="block font-[700] text-dark uppercase leading-[1.05] group-hover:text-coral transition-colors duration-200"
+                    style={{ fontSize: 'clamp(26px, 3.4vw, 48px)' }}
+                  >
+                    {service.heroName}
+                  </span>
+                  <span
+                    className="block mt-2 md:mt-3 text-dark/70 font-[400] leading-[1.45] max-w-[720px]"
+                    style={{ fontSize: 'clamp(15px, 1.4vw, 19px)' }}
+                  >
+                    {service.hubTagline}
+                  </span>
+                </span>
+                <span
+                  aria-hidden="true"
+                  className="shrink-0 text-coral font-[300] leading-none group-hover:translate-x-1 transition-transform duration-200"
+                  style={{ fontSize: 'clamp(28px, 3vw, 44px)' }}
+                >
+                  →
+                </span>
+              </Link>
+            </motion.li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/data/projects.ts
+++ b/data/projects.ts
@@ -9,6 +9,26 @@ export type ProjectSlider = {
   aspect?: string;
 };
 
+// Structured case study: a real problem → design decision → result arc,
+// restated from a project's already-published description (SEO playbook iron
+// rule — never invent problems, decisions, outcomes, metrics or quotes). Only
+// projects whose published copy genuinely supports the arc carry one.
+export type CaseStudy = {
+  problem: string; // the real starting conflict/constraint, from published copy
+  decisions: string[]; // 2–5 key design decisions, each traceable to published copy
+  result: string; // the outcome as published (qualitative is fine; no invented numbers)
+};
+
+// Which service landing page a project's case block cross-links to. Derived
+// from the category heuristic in relatedServiceSlug(); set explicitly on a
+// Project only where the heuristic is wrong (a house, or a public-competition
+// project with no matching commercial service line → the /oferta hub).
+export type RelatedService =
+  | 'projekt-mieszkania'
+  | 'projekt-domu'
+  | 'wnetrza-komercyjne'
+  | 'oferta';
+
 // English copy for a project. Polish stays canonical on the main fields;
 // omitted optional fields fall back to the Polish value (proper nouns).
 export type ProjectTranslation = {
@@ -18,6 +38,8 @@ export type ProjectTranslation = {
   description: string;
   descriptionBlocks?: string[];
   meta?: { title?: string; location?: string };
+  // Faithful English translation of the Polish caseStudy (same shape).
+  caseStudy?: CaseStudy;
 };
 
 export type Project = {
@@ -63,9 +85,23 @@ export type Project = {
   // Padded images rendered noticeably smaller (technical drawings); shares
   // the fullWidthIndices index space
   smallIndices?: number[];
+  // Optional problem → decisions → result block, restated from this project's
+  // own published description (Polish canonical; en block mirrors it).
+  caseStudy?: CaseStudy;
+  // Optional override for the cross-linked service page (see relatedServiceSlug).
+  relatedService?: RelatedService;
   // English copy — resolved by localizeProject() for the en locale
   en: ProjectTranslation;
 };
+
+// The service landing page a project's case block cross-links to. An explicit
+// `relatedService` wins; otherwise the published category maps to a service
+// line — commercial → commercial interiors, residential → apartment design.
+// Houses and public-competition projects carry an explicit override.
+export function relatedServiceSlug(project: Project): RelatedService {
+  if (project.relatedService) return project.relatedService;
+  return project.category === 'komercyjne' ? 'wnetrza-komercyjne' : 'projekt-mieszkania';
+}
 
 // Slider/pair labels are a small closed vocabulary, translated here rather
 // than per project
@@ -99,6 +135,7 @@ export function localizeProject(project: Project, locale: string): Project {
     scope: en.scope,
     description: en.description,
     descriptionBlocks: en.descriptionBlocks ?? project.descriptionBlocks,
+    caseStudy: en.caseStudy ?? project.caseStudy,
     meta: project.meta
       ? {
           ...project.meta,
@@ -154,10 +191,31 @@ const projectCatalog: Project[] = [
       'Na piętrze korytarz zyskuje lamperię z paneli o wzorze „eklerków" w kolorze bordowym, powyżej której pojawia się jasna tapeta z abstrakcyjnym motywem fal. To subtelne przejście między intensywnością a lekkością. Główna sypialnia zachowuje spójność w kolorystycznym układzie, lecz zyskuje nową tożsamość. Tapeta z motywem pływaczek — inspiracja inwestorki — nadaje jej osobisty charakter. Płytki w wydłużonym formacie z ryfowaniem nawiązującym do paneli z korytarza występują w odcieniach burgundu i granatu. Ich podłużny geometryczny wzór lekko wprowadza rytm i dynamikę. Duże lustro i osobne kinkiety rozświetlają przestrzeń. Sypialnia została zaprojektowana jako kobieca oaza. Delikatna tapeta we wzór kwiatowy, zasłony z satynowego sztrusku, granatowa tapicerka zagłówka i duże owalne lustro w ciemnej ramie — wszystko to tworzy atmosferę intymności i komfortu. Siedzisko przed łóżkiem pełni podwójną funkcję: to zarówno wygodne miejsce do siedzenia, jak i pojemnik na przechowywanie.',
     ],
     description: 'Projekt domu jednorodzinnego w podwrocławskich Dobrzykowicach. Reorganizacja istniejącego wnętrza — świadoma praca na zastanym układzie funkcjonalnym z paletą bordów, granatów i szafetu.',
+    relatedService: 'projekt-domu',
+    caseStudy: {
+      problem: 'Projekt nie zaczął się od pustej kartki — to reorganizacja istniejącego wnętrza, świadoma praca na zastanym układzie funkcjonalnym. Architektura domu, część rozwiązań konstrukcyjnych i wybrane elementy wyposażenia miały pozostać niezmienione.',
+      decisions: [
+        'Zamiast radykalnej przebudowy — precyzyjna ingerencja: zachowane struktury uzupełniono o nowe zabudowy, materiały i kolorystyczną narrację.',
+        'Wysoki cokół w odcieniu burgundu prowadzi przez wiatrołap, salon i schody aż do prywatnej strefy piętra, spajając wszystkie kondygnacje.',
+        'Paleta pięciu tonów — bordowego, beżowego, błękitnego, granatowego i szafetu — porządkuje przestrzeń, przypisując każdej strefie własny kolor.',
+        'Przesuwne drzwi ze szkła ornamentowego między wiatrołapem a salonem oszczędzają miejsce i filtrują światło.',
+      ],
+      result: 'Transformacja poprzez warstwy — kolor, fakturę, światło i detal — nadała wnętrzu wyrazisty, lecz spójny charakter i połączyła wszystkie kondygnacje w jedną, konsekwentną historię.',
+    },
     en: {
       title: 'house',
       scope: ['conceptual design', 'construction documentation', 'author\'s supervision'],
       description: 'A project for a single-family house in Dobrzykowice, just outside Wrocław. A reorganisation of the existing interior — deliberate work with the inherited functional layout in a palette of burgundy, navy and sage.',
+      caseStudy: {
+        problem: 'The project did not begin with a blank page — it is a reorganisation of an existing interior, deliberate work with the inherited functional layout. The architecture of the house, some structural solutions and selected pieces of the original fit-out were to remain unchanged.',
+        decisions: [
+          'Instead of a radical rebuild, a precise intervention: the retained structures were complemented with new built-in joinery, materials and a colour narrative.',
+          'A tall burgundy plinth travels through the vestibule, living room and staircase to the private zone upstairs, binding all the storeys together.',
+          'A palette of five tones — burgundy, beige, pale blue, navy and sage — orders the space, giving each zone its own colour.',
+          'Sliding doors of patterned glass between the vestibule and living room save space and filter the light.',
+        ],
+        result: 'Transformation through layers — colour, texture, light and detail — gave the interior a distinctive yet coherent character and bound all the storeys into a single, consistent story.',
+      },
       descriptionBlocks: [
         'The project in Dobrzykowice, set in a two-storey single-family house, did not begin with a blank page. It is a reorganisation of an existing interior — deliberate work with the inherited functional layout and respect for what was already there. The architecture of the house remained unchanged, as did some of the structural solutions and selected pieces of the original fit-out. Instead of a radical rebuild there is precise intervention: the retained structures were complemented with new built-in joinery, materials and a colour narrative that gave the whole a fresh identity. This is a project about transformation through layers — colour, texture, light and detail. About the ability to draw out the potential of an existing space and give it a distinctive yet coherent character. Colour became the tool here. It is neither loud nor literal. It leads subtly and binds all the storeys into a single, consistent story. A tall plinth in a shade of burgundy is a bold, unexpected decorative device that builds rhythm and brings order to the space. It travels through the entrance vestibule, the living room and the staircase, up to the private zone of the upper floor. The palette of the house rests on five tones: burgundy, beige, pale blue, navy and sage. Each has its own place and purpose. Here the colours complement one another rather than compete. The entrance vestibule was treated as more than a pass-through. A wardrobe in pale-blue laminate with an integrated bench seat and a large-format mirror bring comfort and functionality right from the front door. Between the vestibule and the living room are sliding doors of patterned glass. The solution not only saves space but also filters the light, lending it softness and privacy.',
         'In the kitchen, the burgundy flows seamlessly from the corridor into the tall units, creating a strong presence within the interior. It corresponds with the sage-coloured joinery of a compact pantry, concealed behind the casing of the existing fireplace. It is an example of how colour can serve function: each zone has its own palette, which organises the space intuitively. The base cabinets are finished in wood-effect laminate with black and burgundy details. A worktop of beige engineered stone with a subtle pattern adds texture and echoes the terrazzo pattern of the large-format floor tiles. At the end of the kitchen run sits a small bar table — a place for quick breakfasts and conversation while cooking. In the living room, the fireplace was brought to the fore and dressed in glossy fluted ceramic tiles in sage. Their lustrous surface works beautifully with light — especially the indirect side lighting that builds atmosphere throughout the house. The new navy media wall forms a backdrop for a burgundy modular sofa in soft, cosy bouclé fabric. On the wall beside it hangs a retro display cabinet for glassware, with a small chest for a record player beneath it — a nod to analogue rituals. A beige rug with a bold texture completes the whole. In the second part of the living room, built-in cabinetry for books and decorative objects was designed, with a dining zone and a round table set beside it. Curtains of dark-beige faux silk fall softly at the windows, tempering the light and supporting the acoustics. The ground-floor bathroom is a bold juxtaposition. The shower zone features a deep-toned mosaic with a pronounced texture. The ceiling is painted burgundy and the walls are finished with tiled wainscoting in the same shade, its light grout underscoring the rhythm. A black vanity unit beneath a green washbasin and a round mirror complete the composition.',
@@ -202,10 +260,32 @@ const projectCatalog: Project[] = [
       'Dopełnieniem konceptu był projekt identyfikacji wizualnej zachowujący paletę kolorystyczną nawiązującą do wnętrza. Logotyp przywodzi na myśl klasyczne hiszpańskie szyldy i został uzupełniony o szereg prostych ilustracji odnoszących się do głównych produktów z oferty deli. Motyw neonu świni został przeniesiony w formie grafiki na elementy drukowane. Uniformy, czyli granatowe koszulki w połączeniu z burgundowymi fartuchami wykończonymi delikatnym, skórzanym akcentem i żółtym haftem współgrają z wnętrzem sklepu.',
     ],
     description: 'Projekt wnętrz delikatesów iberyjskich we Wrocławiu. Przestrzeń łączy surowe materiały — terrazzo, ciemną stolarkę i czerwone akcenty — z ciepłem drewna i rzemieślniczym charakterem produktów. Całość dopełnia autorska identyfikacja wizualna.',
+    caseStudy: {
+      problem: 'Podłużne, mocno nasłonecznione wnętrze miało oddać atmosferę tradycyjnych hiszpańskich delikatesów i uporządkować ofertę sklepu.',
+      decisions: [
+        'Kolorystyka morskiego granatu, burgundu i żółci przypisuje każdą sekcję sklepu do osobnej barwy i porządkuje przestrzeń.',
+        'Ozdobne lampy i posadzkę z lastryko wykonano na zamówienie specjalnie dla tego wnętrza.',
+        'Burgundowa strefa na tyłach optycznie skraca podłużne wnętrze.',
+        'Drewniany regał w witrynie pełni funkcję wizytówki miejsca i osłony przed nadmiernym słońcem.',
+        'Autorska identyfikacja wizualna i uniformy zachowują paletę wnętrza.',
+      ],
+      result: 'Koncept dopełniły autorska identyfikacja wizualna i uniformy, które współgrają z wnętrzem, spinając całość w jedną, spójną paletę.',
+    },
     en: {
       title: 'dehesa delicatessen',
       scope: ['venue concept', 'interior design', 'furniture design', 'lamp design', 'construction design', 'visual identity', 'uniform design'],
       description: 'Interior design for an Iberian delicatessen in Wrocław. The space combines raw materials — terrazzo, dark joinery and red accents — with the warmth of wood and the artisanal character of the produce. A bespoke visual identity completes the whole.',
+      caseStudy: {
+        problem: 'An elongated, strongly sunlit interior had to evoke the atmosphere of a traditional Spanish delicatessen and bring order to the shop\'s offering.',
+        decisions: [
+          'A palette of sea navy, burgundy and yellow marks out each section of the shop and brings order to the space.',
+          'The decorative lamps and the terrazzo floor were custom-made especially for this interior.',
+          'A burgundy zone at the back visually shortens the elongated interior.',
+          'A wooden rack in the shop window serves as the venue\'s calling card and a screen against excessive sun.',
+          'A bespoke visual identity and uniforms keep to the interior\'s palette.',
+        ],
+        result: 'The concept was completed by a visual identity and uniforms that harmonise with the interior, drawing the whole together into one cohesive palette.',
+      },
       descriptionBlocks: [
         'In a sun-filled interior radiating warmth and authenticity, one finds the atmosphere of a traditional Spanish delicatessen. A colour palette drawn from Almodóvar\'s films lends the space a contemporary character. The design combines sea navy, burgundy and yellow, complemented by strong red accents that echo the old-school slicer visible right from the entrance. Each colour marks out a different section of the shop and brings order to the space. The interior is graced by a timeless, uniform floor of custom-made terrazzo tiles, their mix of aggregates and colours composed specifically for this project. The heart of the deli — a vast counter — is accentuated by decorative lamps designed especially for this interior and made by a Wrocław lighting manufacturer. Red arches paired with delicate beige glass shades, each crowned with a small sphere, lend the interior a retro charm.',
         'In a nod to traditional Spanish shops, the wall behind the counter is finished with decorative tiles in a classic black-and-white pattern. At its centre hangs a neon sign depicting the characteristic cuts of iberico pork — the most important part of the offering. Further along, Spain\'s signature long-cured jamón hams are displayed on steel rails. Niches designed within a built-in unit clad in small, irregular tiles in shades of beige take the place of conventional shop shelving. They hold carefully selected balsamic vinegars, olive oils, wines and other specialities that complement the offering at the counter. At the back of the shop, in a zone accented in burgundy, there is a section with high-quality frozen products and a small office nook. This colour break visually shortens the elongated interior. Owing to the nearby car park and strong sunlight, a honey-toned wooden rack stands in front of the shop window, serving both as the venue\'s calling card and as a screen against excessive sun. Crafted with attention to detail, its precise milled grooves allow the number of wooden louvres to be adjusted as needed.',
@@ -248,10 +328,30 @@ const projectCatalog: Project[] = [
       'Projekt mieszkania zakładał odejście od pierwotnego, bardziej podzielonego układu na rzecz otwartej, płynnie przenikającej się przestrzeni. Zredukowanie zbędnych ścian pozwoliło wydobyć naturalne światło i stworzyć czytelną, funkcjonalną strefę dzienną, w której salon, jadalnia i kuchnia budują spójną, ponadczasową całość. Bazę aranżacji tworzą jasne, ciepłe tonacje oraz duże ilości naturalnego drewna, obecnego w zabudowach stolarskich i na podłogach. Miękkie tkaniny, proste formy mebli i subtelne detale nadają wnętrzu komfortowy charakter. Kolorowe lastryko wprowadza delikatną dynamikę i stanowi motyw przewodni, który przeszywa przestrzeń — od holu po łazienkę. Wyrazistym akcentem są turkusowe płytki pojawiające się na zabudowie szafy w holu oraz na obudowie kominka w strefie dziennej, a także ceglana zabudowa prowadząca z holu do kuchni. W części kuchennej klasyczny marmur Bianco Carrara zastosowany na blatach i zabudowie ściennej równoważy kolorystyczne akcenty i podkreśla ponadczasowy charakter projektu. Efektowne, przesuwne drzwi ze szkła ornamentowego w pionowym profilu oddzielają sypialnię, zapewniając prywatność przy jednoczesnym zachowaniu dostępu światła. Sama sypialnia została zaprojektowana jako przestrzeń wyciszenia — z dużą garderobą w energetycznym kolorze, która stanowi mocny, ale harmonijny akcent. Łazienka konsekwentnie rozwija przyjętą prostą materiałową: kolorowe lastryko, kamień, ceglana szafka pod umywalkę, drewniana zabudowa oraz kwadratowe płytki w szafkowym odcieniu. Spójność materiałów i dbałość o detal budują wnętrze nowoczesne, lecz odporne na zmieniające się trendy — ciepłe, funkcjonalne i ponadczasowe.',
     ],
     description: 'Projekt mieszkania zakładał odejście od podzielonego układu na rzecz otwartej, płynnie przenikającej się przestrzeni. Kolorowe lastryko, turkusowe płytki i marmur Bianco Carrara tworzą ciepłe, ponadczasowe wnętrze.',
+    caseStudy: {
+      problem: 'Pierwotny, mocno podzielony układ mieszkania trzeba było otworzyć na płynnie przenikającą się przestrzeń.',
+      decisions: [
+        'Redukcja zbędnych ścian wydobyła naturalne światło i stworzyła czytelną strefę dzienną łączącą salon, jadalnię i kuchnię.',
+        'Kolorowe lastryko poprowadzono jako motyw przewodni przeszywający przestrzeń od holu po łazienkę.',
+        'Turkusowe płytki i ceglana zabudowa wprowadzają wyraziste akcenty, a marmur Bianco Carrara je równoważy.',
+        'Przesuwne drzwi ze szkła ornamentowego oddzielają sypialnię, zapewniając prywatność bez odcinania światła.',
+      ],
+      result: 'Spójność materiałów i dbałość o detal zbudowały wnętrze ciepłe, funkcjonalne i ponadczasowe — nowoczesne, lecz odporne na zmieniające się trendy.',
+    },
     en: {
       title: 'apartment',
       scope: ['interior conceptual design', 'furniture design', 'interior construction design', 'author\'s supervision'],
       description: 'The apartment design moved away from a compartmentalised layout in favour of an open, fluidly interconnecting space. Colourful terrazzo, turquoise tiles and Bianco Carrara marble create a warm, timeless interior.',
+      caseStudy: {
+        problem: 'The apartment\'s original, heavily compartmentalised layout had to be opened up into a fluidly interconnecting space.',
+        decisions: [
+          'Removing redundant walls drew in natural light and created a legible living zone joining the living room, dining area and kitchen.',
+          'Colourful terrazzo runs through the interior as a leitmotif, from the hall to the bathroom.',
+          'Turquoise tiles and brick-red joinery add bold accents, balanced by Bianco Carrara marble.',
+          'Sliding doors of patterned glass separate the bedroom, ensuring privacy without cutting off the light.',
+        ],
+        result: 'Material coherence and attention to detail produced a warm, functional and timeless interior — contemporary yet resistant to shifting trends.',
+      },
       descriptionBlocks: [
         'The design for this apartment moved away from the original, more compartmentalised layout in favour of an open, fluidly interconnecting space. Removing redundant walls drew in natural light and created a legible, functional living zone in which the living room, dining area and kitchen form a coherent, timeless whole. The scheme is grounded in light, warm tones and generous amounts of natural wood, present in the built-in joinery and on the floors. Soft fabrics, simple furniture forms and subtle details lend the interior a comfortable character. Colourful terrazzo introduces a gentle dynamism and serves as the leitmotif threading through the space — from the hall to the bathroom. Turquoise tiles provide a bold accent, appearing on the built-in wardrobe in the hall and on the fireplace surround in the living zone, as does the brick-red joinery leading from the hall into the kitchen. In the kitchen, classic Bianco Carrara marble on the worktops and wall cladding balances the colour accents and underscores the timeless character of the design. Striking sliding doors of vertically reeded glass separate the bedroom, ensuring privacy while still admitting light. The bedroom itself was conceived as a space of calm — with a large wardrobe in an energising colour that forms a strong yet harmonious accent. The bathroom consistently extends the established material palette: colourful terrazzo, stone, a brick-red washbasin cabinet, wooden joinery and square tiles in a sage shade. Material coherence and attention to detail build an interior that is contemporary yet resistant to shifting trends — warm, functional and timeless.',
       ],
@@ -288,10 +388,28 @@ const projectCatalog: Project[] = [
       'Projekt wnętrza powstał z poszanowaniem postindustrialnego charakteru istniejącego budynku, którego największym atutem jest zachowany ceglany sufit nadający przestrzeni wyjątkowy rytm. Historyczna tkanka stanowi tło dla współczesnej aranżacji, opartej na wyrazistych akcentach kolorystycznych i świadomie budowanej atmosferze. Centralnym elementem jest bar, zaakcentowany intensywnym odcieniem oranżu, który przyciąga uwagę gości już od wejścia. Eksponowane kolekcje win stają się integralną częścią wystroju, budując tożsamość miejsca. Projekt opiera się na równowadze pomiędzy otwartością a kameralnością, gdzie gastronomia, wino i architektura tworzą spójną opowieść o wspólnym doświadczaniu.',
     ],
     description: 'Winobar w postindustrialnym wnętrzu w centrum Łodzi. Zachowany ceglany sufit spotyka intensywny oranż baru, a eksponowane kolekcje win budują tożsamość miejsca. Projekt powstał we współpracy z blsk.studio.',
+    caseStudy: {
+      problem: 'Wnętrze powstawało w istniejącym, postindustrialnym budynku, którego największym atutem jest zachowany ceglany sufit nadający przestrzeni wyjątkowy rytm.',
+      decisions: [
+        'Projekt poprowadzono z poszanowaniem historycznej tkanki, która stała się tłem dla współczesnej aranżacji.',
+        'Centralny bar zaakcentowano intensywnym odcieniem oranżu, przyciągającym uwagę już od wejścia.',
+        'Eksponowane kolekcje win uczyniono integralną częścią wystroju, budującą tożsamość miejsca.',
+      ],
+      result: 'Projekt opiera się na równowadze między otwartością a kameralnością, w której gastronomia, wino i architektura tworzą spójną opowieść o wspólnym doświadczaniu.',
+    },
     en: {
       title: 'wine bar',
       scope: ['interior conceptual design', 'food concept'],
       description: 'A wine bar in a post-industrial interior in the centre of Łódź. The preserved brick ceiling meets the intense orange of the bar, while displayed wine collections build the identity of the place. Designed in collaboration with blsk.studio.',
+      caseStudy: {
+        problem: 'The interior took shape in an existing post-industrial building whose greatest asset is the preserved brick ceiling that gives the space a distinctive rhythm.',
+        decisions: [
+          'The design was led with respect for the historic fabric, which became a backdrop for a contemporary arrangement.',
+          'The central bar was accented in an intense shade of orange that draws attention from the moment guests enter.',
+          'Displayed wine collections were made an integral part of the décor, building the identity of the place.',
+        ],
+        result: 'The design rests on a balance between openness and intimacy, where gastronomy, wine and architecture form a coherent story of shared experience.',
+      },
       descriptionBlocks: [
         'The interior was designed with respect for the post-industrial character of the existing building, whose greatest asset is the preserved brick ceiling, lending the space a distinctive rhythm. The historic fabric forms a backdrop for a contemporary arrangement built on bold colour accents and a deliberately crafted atmosphere. The centrepiece is the bar, accented in an intense shade of orange that draws guests\' attention from the moment they enter. Displayed wine collections become an integral part of the décor, building the identity of the place. The design rests on a balance between openness and intimacy, where gastronomy, wine and architecture form a coherent story of shared experience.',
       ],
@@ -414,10 +532,30 @@ const projectCatalog: Project[] = [
       'Już od pierwszego kontaktu z przestrzenią wiedzieliśmy, że jej potencjał kryje się w uproszczeniu. Projekt tej kancelarii potraktowaliśmy jako proces porządkowania: funkcji i formy. Bazą stała się neutralna paleta bieli i beżu, pozwalająca wyciszyć przestrzeń i stworzyć eleganckie, ponadczasowe tło. Wprowadziliśmy subtelne, ale zdecydowane akcenty kolorystyczne, które nadają wnętrzu charakteru, nie zaburzając jego profesjonalnego tonu. Jednym z najważniejszych rozwiązań w projekcie jest ukrycie rozbudowanej strefy przechowywania za miękką, lnianą zasłoną. Rozwiązanie to porządkuje wizualnie przestrzeń, a jednocześnie buduje dużą, spokojną płaszczyznę, która wycisza wnętrze i nadaje mu rytm. Tkanina pochłania dźwięk, łagodząc akustykę i sprzyjając skupieniu. Pracuje też ze światłem, delikatnie je filtrując i uszlachetniając wnętrze. Centralnym punktem przestrzeni jest zaprojektowany przez nas stół. Połączenie stali nierdzewnej z blatem z drewnianego lastryko stanowi wyważony dialog między precyzją a materią. Towarzyszą mu odnowione krzesła Rey i charakterystyczna lampa Lexavala. Kluczową rolę w kształtowaniu charakteru wnętrza odegrał odnowiony parkiet drewniany, zachowany jako element tożsamości miejsca. Ociepla i scala wszystkie elementy w spójną całość. System stalowych regałów zawieszony na ścianie pozwala na selektywną ekspozycję. W efekcie powstała przestrzeń łącząca nowoczesną elegancję z poczuciem ciepła, uporządkowana i czytelna, a przy tym budująca zaufanie już od pierwszego spojrzenia.',
     ],
     description: 'Kameralna kancelaria we Wrocławiu, w której projekt stał się procesem porządkowania funkcji i formy. Neutralna paleta bieli i beżu, lniana zasłona skrywająca strefę przechowywania oraz autorski stół z blatem z drewnianego lastryko budują nowoczesną elegancję z poczuciem ciepła.',
+    caseStudy: {
+      problem: 'Potencjał tej kameralnej kancelarii krył się w uproszczeniu — projekt potraktowaliśmy jako proces porządkowania funkcji i formy.',
+      decisions: [
+        'Neutralna paleta bieli i beżu wycisza przestrzeń i tworzy ponadczasowe tło.',
+        'Rozbudowaną strefę przechowywania ukryto za miękką, lnianą zasłoną, która porządkuje wnętrze, pochłania dźwięk i filtruje światło.',
+        'Autorski stół ze stali nierdzewnej z blatem z drewnianego lastryko stał się centralnym punktem wnętrza.',
+        'Odnowiony parkiet zachowano jako element tożsamości miejsca, a stalowe regały na ścianie pozwalają na selektywną ekspozycję.',
+      ],
+      result: 'Powstała przestrzeń uporządkowana i czytelna, łącząca nowoczesną elegancję z poczuciem ciepła i budująca zaufanie już od pierwszego spojrzenia.',
+    },
     en: {
       title: 'law office',
       scope: ['interior conceptual design', 'furniture design', 'interior construction design', 'author\'s supervision'],
       description: 'An intimate law office in Wrocław, where the design became a process of ordering function and form. A neutral palette of whites and beiges, a linen curtain concealing the storage zone and a bespoke table with a wood terrazzo top build modern elegance with a sense of warmth.',
+      caseStudy: {
+        problem: 'The potential of this intimate law office lay in simplification — we approached the design as a process of ordering function and form.',
+        decisions: [
+          'A neutral palette of whites and beiges calms the space and creates a timeless backdrop.',
+          'The extensive storage zone was concealed behind a soft linen curtain that orders the interior, absorbs sound and filters the light.',
+          'A bespoke table of stainless steel with a wood terrazzo top became the centrepiece of the interior.',
+          'The restored parquet was preserved as an element of the place\'s identity, while wall-mounted steel shelving allows for selective display.',
+        ],
+        result: 'The result is an ordered, legible space that combines modern elegance with a sense of warmth and builds trust from the very first glance.',
+      },
       descriptionBlocks: [
         'From our very first encounter with the space we knew that its potential lay in simplification. We approached the design of this law office as a process of ordering: of function and of form. A neutral palette of whites and beiges became the base, calming the space and creating an elegant, timeless backdrop. We introduced subtle yet decisive colour accents that lend the interior character without disturbing its professional tone. One of the most important moves in the design is the concealment of the extensive storage zone behind a soft linen curtain. This move visually orders the space while building a large, calm plane that quiets the interior and gives it rhythm. The fabric absorbs sound, softening the acoustics and aiding concentration. It also works with the light, gently filtering it and refining the interior. The centrepiece of the space is a table of our own design. The pairing of stainless steel with a wood terrazzo top forms a balanced dialogue between precision and matter. It is accompanied by restored Rey chairs and a distinctive Lexaval lamp. A key role in shaping the interior\'s character is played by the restored wooden parquet, preserved as an element of the place\'s identity. It warms and binds all the elements into a coherent whole. A system of steel shelving mounted on the wall allows for selective display. The result is a space that combines modern elegance with a sense of warmth — ordered and legible, and one that builds trust from the very first glance.',
       ],
@@ -476,11 +614,32 @@ const projectCatalog: Project[] = [
       'Piętro biblioteki zostało podzielone na dwie wyraźne strefy funkcjonalne, odpowiadające różnym grupom użytkowników oraz ich potrzebom. Projekt zakłada stworzenie przestrzeni elastycznych, przyjaznych i sprzyjających zarówno pracy, jak i odpoczynkowi, a także zapewnienie odpowiedniego zaplecza dla pracowników. W prawym skrzydle ulokowana została mediateka młodzieżowa, w której głównym kolorem przewodnim jest ceglany. Jego ciepło buduje atmosferę swobody i zachęca młodych użytkowników do spędzania tu czasu. Centralna część tej strefy została podzielona regałami, tworząc bardziej kameralne wnętrza: z długim stołem do pracy, spotkań i gier oraz miękkimi meblami, które sprzyjają czytaniu i odpoczynkowi. Wzdłuż okien zaplanowano blaty do pracy z indywidualnym oświetleniem, wyposażone w możliwość podłączenia tabletu lub laptopa. Pojawiają się tu także miękkie sofki i wygodne fotele ze stolikami, tworzące komfortowe mikroprzestrzenie. Ciekawym elementem jest zastosowanie lustrzanej okładziny ponad regałami, która optycznie powiększa wnętrze oraz nadaje mu lekkości. W lewym skrzydle mieści się biblioteka dla dzieci, zaprojektowana w przewodnim niebieskim kolorze, sprzyjającym skupieniu, wyciszeniu i poczuciu bezpieczeństwa. Wysokie regały dzielą przestrzeń na mniejsze, przyjazne dla najmłodszych obszary, a w ich strukturze umieszczono okna do siedzenia, które kadrują widoki i tworzą atrakcyjne miejsca do lektury. Całość uzupełniają tapicerowane siedziska o obłych, miękkich kształtach, bezpieczne i zachęcające do zabawy oraz odpoczynku. Naprzeciwko biblioteki znajduje się strefa relaksu dla dzieci, w kolorze ceglanym. Umieszczono tu niski regał z książkami i miękkie elementy sprzyjające zabawie i eksploracji. W ramach tej części piętra wydzielono również pomieszczenie terapeutyczne, przeznaczone dla osób w różnym wieku, w tym w spektrum autyzmu. Zaprojektowane zostało w kojącym zielonym kolorze, aby wspierać poczucie bezpieczeństwa i komfort sensoryczny. Dalszą część lewego skrzydła zajmuje kompleks pomieszczeń socjalnych, biurowych i magazynowych, stanowiących zaplecze dla pracowników biblioteki.',
     ],
     description: 'Konkursowy projekt koncepcyjny wnętrz wojewódzkiej i miejskiej biblioteki publicznej w Gdańsku. Trzy barwy przewodnie — ceglany, zielony i niebieski — porządkują przestrzenie parteru i piętra, tworząc miejsce otwarte, elastyczne i dostępne dla wszystkich.',
+    relatedService: 'oferta',
+    caseStudy: {
+      problem: 'Konkursowa koncepcja zakładała stworzenie przestrzeni inkluzywnych, otwartych i nieonieśmielających — dostępnych dla wszystkich użytkowników bez względu na wiek, potrzeby czy sposób korzystania z biblioteki — oraz elastycznych funkcjonalnie i przyszłościowo.',
+      decisions: [
+        'Koncept oparto na świadomym wykorzystaniu teorii barw i trzech barwach przewodnich: ceglanej, zielonej i niebieskiej, które różnicują nastrój i porządkują strefy.',
+        'Okrągła lada recepcyjna o inkluzywnej, dostępnej z każdej strony formie organizuje ruch na parterze.',
+        'Mobilne meble pozwalają szybko przearanżować przestrzeń — nawet pod większe wydarzenia kulturalne.',
+        'Pomieszczenie terapeutyczne dla osób w różnym wieku, w tym w spektrum autyzmu, zaprojektowano w kojącym zielonym kolorze.',
+      ],
+      result: 'Zaprojektowane wnętrze nie tylko spełnia wymagania funkcjonalne, ale przede wszystkim buduje doświadczenie — spokojne, bezpieczne, inspirujące i dostępne dla wszystkich.',
+    },
     en: {
       title: 'library',
       meta: { title: 'Joseph Conrad Korzeniowski Voivodeship and Municipal Public Library - Competition to develop an interior architecture conceptual design' },
       scope: ['venue concept', 'interior design', 'furniture design', 'lamp design'],
       description: 'Competition-stage interior conceptual design for the voivodeship and municipal public library in Gdańsk. Three signature colours — brick red, green and blue — organise the ground- and first-floor spaces, creating a place that is open, flexible and accessible to all.',
+      caseStudy: {
+        problem: 'The competition concept set out to create inclusive, open and unintimidating spaces — accessible to all users regardless of age, needs or how they use the library — and flexible both functionally and for the future.',
+        decisions: [
+          'The concept was built on a deliberate use of colour theory and three signature colours — brick red, green and blue — that differentiate mood and order the zones.',
+          'A round reception desk, inclusive and approachable from every side, organises circulation on the ground floor.',
+          'Mobile furniture allows the space to be rearranged quickly — even for larger cultural events.',
+          'A therapy room for people of various ages, including those on the autism spectrum, is designed in a soothing green.',
+        ],
+        result: 'The designed interior not only meets functional requirements but, above all, builds an experience — calm, safe, inspiring and accessible to everyone.',
+      },
       descriptionBlocks: [
         'Our overriding goal in designing the interiors of the first floor and ground floor of the building at Targ Rakowy 5/6 in Gdańsk was to create inclusive, open and unintimidating spaces — places accessible to all users, regardless of age, needs or how they use the library. Flexibility was key for us: functional flexibility, allowing the library to carry out its current tasks, and future-proofing, allowing it to adapt smoothly to new activities, ways of working and forms of participation. To achieve this, we built the concept on a deliberate use of colour theory and its effects — it is colour that became the foundation of the visual and emotional coherence of the entire project. In interior design, colour does not play a merely aesthetic role — it is one of the key means of influencing users\' perception, wellbeing and behaviour. Colour theory describes the relationships between colours, their influence on how a space is perceived and the psychophysical reactions they provoke. A well-chosen palette can aid concentration, calm or stimulate, bring order to a space or guide movement through it. In a library — a place that brings together diverse activities, from work and study through recreation to meetings and events — colour becomes an ally in building mood, functional zoning and an intuitive interior. On this basis we chose three signature colours with strong yet complementary properties: brick red, green and blue. Each carries different meanings, supports a different type of activity and helps shape the character of the place. Set alongside one another, these colours allow the spaces to differ in mood while retaining a cohesive, harmonious identity.',
         'Brick red: Brick red brings warmth, cosiness and a sense of closeness to the interior. It encourages relaxation and an intimate atmosphere, invites calm interaction and gives an impression of naturalness. It evokes authenticity, the earth and traditional values, creating friendly surroundings. Blue: Blue lends the space freshness, harmony and a feeling of breathing room. It soothes the emotions, aids concentration and supports logical thinking, creating ideal conditions for mental work. It inspires trust and a sense of stability, bringing a modern, professional character. Green: Green has a calming, harmonising effect, letting the eye rest and creating an atmosphere of tranquillity. It fosters focus and gently orders the space without imposing itself on the user. As a colour tied to nature, it brings freshness, authenticity and a sense of balance to the interior. Together, the chosen palette — brick red, green and blue — forms a multidimensional visual language that supports the idea of the library as an open, friendly and flexible space. Each colour performs a specific role, answering the needs of different user groups and types of activity. This deliberate work with colour produces an interior that not only meets functional requirements but, above all, builds an experience — calm, safe, inspiring and accessible to everyone.',
@@ -620,10 +779,30 @@ const projectCatalog: Project[] = [
       'Prywatna część mieszkania utrzymana jest w równie spokojnym tonie. W sypialni główną rolę odgrywa wielkoformatowa tapeta w odcieniach błękitu nadając wnętrzu wyrazisty charakter. Tuż obok, oddzielone stalową witryną z ornamentowym szkłem, znajduje się kompaktowe miejsce do pracy. Transparentna przegroda pozwala zachować dostęp światła i wizualną lekkość, jednocześnie subtelnie wyznaczając granicę między strefą odpoczynku a pracy.\nŁazienka dopełnia opowieść o mieszkaniu. Pudrowy róż wielkoformatowych płytek spotyka się z błękitną zabudową, tworząc spokojną, lecz niebanalną kompozycję. Mikrocement w beżowym kolorze zwiększa komfort użytkowania, a blaty z lastryko, robione na specjalne zamówienie oraz duże lustra dodają wnętrzu elegancji i optycznej lekkości.\nCałość to przykład projektu, w którym estetyka wynika z uważnego projektowania codzienności. Zamiast nadmiaru form i dekoracji pojawia się świadomie zaplanowany porządek, sprzyjający koncentracji, odpoczynkowi i wspólnemu życiu. To wnętrze, które nie tylko dobrze wygląda, ale przede wszystkim odpowiada na realne potrzeby swoich mieszkańców.',
     ],
     description: 'Mieszkanie we Wrocławiu zaprojektowane z myślą o rodzinie i potrzebach związanych z ADHD — wnętrze terapeutyczne, które koi układ nerwowy i daje poczucie harmonii. Paleta ciepłych beży, błękitów oraz różu uzupełniona o naturalne drewno.',
+    caseStudy: {
+      problem: 'Mieszkanie zaprojektowano dla rodziny, a jednym z kluczowych założeń było uwzględnienie potrzeb związanych z ADHD – stworzenie wnętrza terapeutycznego, które będzie działało kojąco na układ nerwowy i dawało poczucie harmonii.',
+      decisions: [
+        'Czytelny układ funkcjonalny, ograniczenie otwartych półek i proste zabudowy nadały przestrzeni wizualny porządek.',
+        'Obłości mebli i miękkość naturalnych tkanin koją zmysły.',
+        'Spokojna paleta ciepłych beży, błękitów i różu, uzupełniona o naturalne drewno, odpowiada na życzenie mieszkańców, by kolory pozostały stonowane.',
+        'Błękitna zabudowa z lustrzanymi frontami ukrywa telewizor i wzmacnia wrażenie przestronności, a stalowa witryna z ornamentowym szkłem wyznacza granicę między strefą odpoczynku a pracy, nie odcinając światła.',
+      ],
+      result: 'Estetyka wynika tu z uważnego projektowania codzienności — świadomie zaplanowany porządek sprzyja koncentracji, odpoczynkowi i wspólnemu życiu, odpowiadając na realne potrzeby mieszkańców.',
+    },
     en: {
       title: 'apartment',
       scope: ['interior conceptual design', 'furniture design', 'interior construction design', 'author\'s supervision'],
       description: 'An apartment in Wrocław designed with a family and their ADHD-related needs in mind — a therapeutic interior that soothes the nervous system and brings a sense of harmony. A palette of warm beiges, blues and pinks, complemented by natural wood.',
+      caseStudy: {
+        problem: 'The apartment was designed for a family, and one of the key premises was to accommodate ADHD-related needs — to create a therapeutic interior that calms the nervous system and brings a sense of harmony.',
+        decisions: [
+          'A legible functional layout, a minimum of open shelving and simple built-in joinery lend the space visual order.',
+          'Rounded furniture forms and the softness of natural fabrics soothe the senses.',
+          'A calm palette of warm beiges, blues and pinks, complemented by natural wood, answers the residents\' wish to keep the colours muted.',
+          'Blue cabinetry with mirrored fronts conceals the television and heightens the sense of space, while a steel-framed partition of patterned glass marks the boundary between rest and work without cutting off the light.',
+        ],
+        result: 'Here aesthetics grow out of the attentive design of everyday life — a deliberately planned order that favours concentration, rest and shared living, answering the real needs of the residents.',
+      },
       descriptionBlocks: [
         'An apartment designed for a family whose home was to become a space that supports everyday life. One of the key premises of the project was to accommodate ADHD-related needs — to create a therapeutic interior that calms the nervous system and brings a sense of harmony. A legible functional layout, a minimum of open shelving and simple built-in joinery lend the space visual order, while rounded furniture forms and the softness of natural fabrics soothe the senses. The future residents wanted colour, but in calm tones — hence a palette of warm beiges, blues and pinks, complemented by elements of natural wood.\nThe heart of the apartment is the open-plan living area, designed as a place to spend time together. A kitchen with an island organises the household\'s daily life — this is where conversations unfold over cooking and where the household gathers over morning coffee. Warm oak veneer is set against a chocolate-brown island in stained MDF, a steel extractor hood and a bold accent of blue lamps that subtly enliven the muted composition.\nFlowing seamlessly from the kitchen, the living room offers a range of scenarios for use. A modular sofa makes it easy to adapt the space for family film nights or a quiet evening with a book. Blue built-in cabinetry discreetly conceals the television, keeping the interior visually calm, while mirrored fronts further heighten the sense of spaciousness. The other end of the living room holds a dining area with an extendable table, accompanied by light bentwood chairs made in Poland.',
         'The private part of the apartment keeps to an equally calm tone. In the bedroom, the leading role belongs to a large-format wallpaper in shades of blue, giving the interior a distinctive character. Right beside it, separated by a steel-framed partition of patterned glass, sits a compact workspace. The transparent screen preserves daylight and visual lightness while subtly marking the boundary between rest and work.\nThe bathroom completes the apartment\'s story. The powder pink of large-format tiles meets blue cabinetry in a calm yet far-from-ordinary composition. Beige microcement adds everyday comfort, while custom-made terrazzo countertops and generous mirrors lend the interior elegance and optical lightness.\nThe result is an example of a project in which aesthetics grow out of the attentive design of everyday life. In place of an excess of forms and decoration there is a deliberately planned order — one that favours concentration, rest and shared living. It is an interior that not only looks good, but above all answers the real needs of the people who live in it.',
@@ -671,11 +850,31 @@ const projectCatalog: Project[] = [
       'Centralnym punktem biura jest strefa open office, zaprojektowana z myślą o maksymalnej elastyczności. Duże wspólne biurko można w razie potrzeby rozdzielić na dwa niezależne stanowiska, a system oświetlenia oparty na szynoprzewodach pozwala swobodnie dopasować układ opraw do zmieniającej się konfiguracji mebli. Dzięki temu przestrzeń może ewoluować wraz z potrzebami firmy.\nDrugie biuro pełni podwójną funkcję – jest zarówno miejscem codziennej pracy, jak i przestrzenią spotkań z klientami. Centralnie usytuowane biurko zostało zaprojektowane specjalnie na potrzeby tego wnętrza i detalami nawiązuje do wyposażenia strefy open office, budując spójną tożsamość całego projektu. Ważnym elementem pomieszczenia jest także duży stół konferencyjny z blatem wykończonym fornirem z ciemnej czeczoty. Ustawiony na tle muralu z logo marki staje się naturalnym centrum spotkań i prezentacji, podkreślając indywidualny charakter siedziby.\nProjekt pokazuje, że wyrazista identyfikacja wizualna może współistnieć z racjonalnym podejściem do projektowania. Zamiast całkowitej przebudowy postawiono na twórcze wykorzystanie zastanej przestrzeni, nadając jej nową energię poprzez kolor, grafikę i elastyczne rozwiązania funkcjonalne.',
     ],
     description: 'Siedziba firmy Dobry Materiał we Wrocławiu — biuro, które odzwierciedla dynamiczny charakter marki. Zastana przestrzeń zyskała nową energię dzięki mocnym akcentom kolorystycznym, wielkoformatowym grafikom i mobilnym parawanom.',
+    caseStudy: {
+      problem: 'Siedziba miała odzwierciedlać dynamiczny charakter marki, a głównym założeniem było pozostawienie istniejącej bazy — koloru ścian, elektryki, odnowionego parkietu i stolarki — zamiast całkowitej przebudowy.',
+      decisions: [
+        'Istniejącą bazę uzupełniono o mocne akcenty kolorystyczne i graficzne nawiązujące do energetycznych kolorów etykiet napojów.',
+        'Zamiast tradycyjnej recepcji strefę wejściową urządzono jako otwartą przestrzeń relaksu z ekspozycją, aneksem kawowym, projektorem i konsolą.',
+        'Mobilne parawany porządkują otwartą przestrzeń i ukrywają instalacje, a każdy pełni dodatkową funkcję: zielony to ekspozytor, pomarańczowy — tablica na notatki.',
+        'Strefę open office zaprojektowano elastycznie: wspólne biurko można rozdzielić na dwa stanowiska, a oświetlenie na szynoprzewodach dopasować do zmian układu.',
+      ],
+      result: 'Zastana przestrzeń zyskała nową energię dzięki kolorowi, grafice i elastycznym rozwiązaniom — dowód, że wyrazista identyfikacja wizualna może współistnieć z racjonalnym podejściem do projektowania.',
+    },
     en: {
       title: 'Dobry Materiał office',
       meta: { title: 'Dobry Materiał® company office' },
       scope: ['interior conceptual design', 'furniture design', 'interior construction design', 'author\'s supervision'],
       description: 'The Wrocław headquarters of Dobry Materiał — an office that reflects the brand\'s dynamic character. The existing space gained new energy through bold colour accents, large-format graphics and movable screens.',
+      caseStudy: {
+        problem: 'The headquarters was to reflect the brand\'s dynamic character, and the guiding principle was to retain the existing fabric — the wall colours, the electrics, the restored parquet and the joinery — rather than rebuild it entirely.',
+        decisions: [
+          'The existing fabric was layered with bold colour and graphic accents echoing the energetic colours of the drinks labels.',
+          'In place of a traditional reception, the entrance was arranged as an open, relaxed zone with a product display, a coffee corner, a projector and a games console.',
+          'Movable screens bring order to the open space and conceal the services, each with an added role: the green one a product display, the orange one a pinboard for notes.',
+          'The open-plan zone was designed for flexibility: the shared desk can be split into two workstations and the track lighting rearranged to follow the furniture.',
+        ],
+        result: 'The existing space gained new energy through colour, graphics and flexible solutions — proof that a bold visual identity can coexist with a rational approach to design.',
+      },
       descriptionBlocks: [
         'The Dobry Materiał headquarters was conceived as a space that reflects the character of the brand — dynamic, expressive and open to change. The guiding principle was to retain the existing fabric — the wall colours, the electrics, the restored wooden parquet, the joinery — and layer it with bold colour and graphic accents echoing the energetic colours of the drinks labels.\nThe entrance zone best captures the brand\'s personality — relaxed, open and geared towards building relationships. It is also a space for unwinding: in place of a traditional reception desk there is a display of Dobry Materiał products, a coffee corner and a spot for spending time together, complete with a projector and a games console. A soft sofa and a curtain subtly set apart the social area, while large-format graphics with a neon accent bring the brand\'s energy into the interior from the very first moments.\nThe movable screens are a signature element of the project, bringing order to the open space while concealing the existing services. Each one performs an additional role — the green one became a product display, while the orange one was turned into a pinboard for notes, inspiration and working materials.',
         'The heart of the office is the open-plan zone, designed for maximum flexibility. The large shared desk can be split into two independent workstations when needed, and a track lighting system allows the luminaires to be freely rearranged to follow the changing furniture layout. As a result, the space can evolve along with the company\'s needs.\nThe second office plays a dual role — it is both a place for everyday work and a setting for client meetings. The centrally positioned desk was designed specifically for this interior, its details referencing the furnishings of the open-plan zone and building a coherent identity across the whole project. Another key element of the room is the large conference table with a top finished in dark burl veneer. Set against a mural with the brand\'s logo, it becomes the natural focal point of meetings and presentations, underlining the individual character of the headquarters.',
@@ -718,12 +917,33 @@ const projectCatalog: Project[] = [
       'Projekt toalet redefiniuje przestrzeń o czysto użytkowej funkcji, czyniąc z niej integralny element doświadczenia architektonicznego teatru. To miejsce, które nie stanowi jedynie zaplecza budynku, lecz naturalną kontynuację jego narracji – przestrzeń budującą nastrój jeszcze przed wejściem na widownię i pozostającą w pamięci długo po zakończeniu spektaklu.\nInspiracją dla koncepcji stał się język teatralnej scenografii. Wnętrza rozwijają się sekwencyjnie, odsłaniając kolejne plany i perspektywy, w których światło, kolor i proporcje prowadzą użytkownika przez starannie skomponowaną opowieść. Poszczególne strefy zyskują własną tożsamość, a jednocześnie pozostają częścią spójnej kompozycji opartej na rytmie kontrastów i przenikających się przestrzeni.\nPaleta barw została zbudowana wokół ciepłych, naturalnych tonów przełamanych głęboką zielenią oraz ciemnymi akcentami. Miedziane detale subtelnie wprowadzają elegancję i szlachetność, natomiast miękkie tekstylia stanowią nawiązanie do teatralnej kurtyny – symbolicznej granicy pomiędzy rzeczywistością a światem przedstawienia.\nPowściągliwe oświetlenie dopełnia kompozycję, wydobywając głębię przestrzeni i podkreślając jej sceniczny charakter. Dzięki temu toalety stają się czymś więcej niż funkcjonalnym elementem programu budynku – są kolejnym aktem teatralnego doświadczenia, w którym architektura odgrywa rolę cichego scenografa.',
     ],
     description: 'Konkursowy projekt koncepcyjny toalet Teatru Wielkiego Opery Narodowej w Warszawie. Język teatralnej scenografii — głęboka zieleń, miedziane detale i miękkie tekstylia — czyni z przestrzeni użytkowej kolejny akt teatralnego doświadczenia.',
+    relatedService: 'oferta',
+    caseStudy: {
+      problem: 'Konkursowa koncepcja redefiniuje przestrzeń o czysto użytkowej funkcji, czyniąc z toalet integralny element doświadczenia architektonicznego teatru.',
+      decisions: [
+        'Inspiracją stał się język teatralnej scenografii — wnętrza rozwijają się sekwencyjnie, odsłaniając kolejne plany i perspektywy.',
+        'Paleta ciepłych, naturalnych tonów została przełamana głęboką zielenią i ciemnymi akcentami.',
+        'Miedziane detale wprowadzają elegancję, a miękkie tekstylia nawiązują do teatralnej kurtyny.',
+        'Powściągliwe oświetlenie wydobywa głębię i sceniczny charakter przestrzeni.',
+      ],
+      result: 'W koncepcji toalety stają się czymś więcej niż funkcjonalnym elementem programu budynku — kolejnym aktem teatralnego doświadczenia, w którym architektura gra rolę cichego scenografa.',
+    },
     en: {
       title: 'theatre toilets',
       location: 'Warsaw',
       meta: { title: 'toilets of the Teatr Wielki – Polish National Opera in Warsaw - competition to develop an interior architecture conceptual design' },
       scope: ['interior conceptual design'],
       description: 'Competition-stage conceptual design for the toilets of the Teatr Wielki – Polish National Opera in Warsaw. The language of stage scenography — deep green, copper details and soft textiles — turns a utilitarian space into another act of the theatrical experience.',
+      caseStudy: {
+        problem: 'The competition concept redefines a space of purely utilitarian function, making the toilets an integral part of the theatre\'s architectural experience.',
+        decisions: [
+          'The language of stage scenography became the inspiration — the interiors unfold sequentially, revealing successive planes and perspectives.',
+          'A palette of warm, natural tones is offset by deep green and dark accents.',
+          'Copper details bring elegance, while soft textiles allude to the theatre curtain.',
+          'Restrained lighting draws out the depth and scenic character of the space.',
+        ],
+        result: 'In the concept, the toilets become more than a functional element of the building\'s programme — another act of the theatrical experience, in which architecture plays the role of a quiet scenographer.',
+      },
       descriptionBlocks: [
         'The design of the toilets redefines a space of purely utilitarian function, making it an integral part of the theatre\'s architectural experience. This is a place that is not merely the building\'s back-of-house, but a natural continuation of its narrative – a space that sets the mood even before one enters the auditorium and lingers in the memory long after the performance has ended.\nThe concept draws on the language of stage scenography. The interiors unfold sequentially, revealing successive planes and perspectives in which light, colour and proportion guide the user through a carefully composed story. Individual zones gain identities of their own while remaining part of a coherent composition built on a rhythm of contrasts and interpenetrating spaces.\nThe colour palette is built around warm, natural tones offset by deep green and dark accents. Copper details bring a subtle note of elegance and refinement, while soft textiles allude to the theatre curtain – the symbolic boundary between reality and the world of the performance.\nRestrained lighting completes the composition, drawing out the depth of the space and underscoring its scenic character. The toilets thus become more than a functional element of the building\'s programme – they are another act of the theatrical experience, in which architecture plays the role of a quiet scenographer.',
       ],
@@ -772,9 +992,27 @@ const projectCatalog: Project[] = [
       'Punktem wyjścia projektu była rearanżacja zastanej przestrzeni i nadanie jej nowego porządku bez radykalnej ingerencji w istniejącą strukturę. Wnętrze zyskało wyrazistą identyfikację dzięki mocnym plamom bordo i zieleni, które organizują przestrzeń i budują jej charakter. Naturalne drewno ociepla surowy charakter otwartej, industrialnej hali, wprowadzając do wnętrza bardziej kameralną i przyjazną atmosferę. Projekt został pomyślany jako proces rozłożony w czasie – zrealizowany etap stanowi świadomy początek przemiany, której kolejne rozdziały będą stopniowo dopełniać nową tożsamość miejsca.\nNa razie odsłaniamy jedynie pierwszy akt tej metamorfozy. Na pełną opowieść i wszystkie detale przyjdzie czas wraz z zakończeniem kolejnych etapów realizacji.',
     ],
     description: 'Rearanżacja industrialnej hali foodhallu Piazza we Wrocławiu. Mocne plamy bordo i zieleni organizują przestrzeń, a naturalne drewno ociepla jej surowy charakter — zrealizowany etap to pierwszy akt rozłożonej w czasie metamorfozy.',
+    caseStudy: {
+      problem: 'Punktem wyjścia była rearanżacja zastanej, industrialnej hali i nadanie jej nowego porządku bez radykalnej ingerencji w istniejącą strukturę.',
+      decisions: [
+        'Mocne plamy bordo i zieleni organizują przestrzeń i budują wyrazistą identyfikację wnętrza.',
+        'Naturalne drewno ociepla surowy charakter otwartej, industrialnej hali.',
+        'Projekt pomyślano jako proces rozłożony w czasie, w którym zrealizowany etap jest świadomym początkiem przemiany.',
+      ],
+      result: 'Zrealizowany etap to pierwszy akt rozłożonej w czasie metamorfozy — pełną opowieść dopełnią kolejne etapy realizacji.',
+    },
     en: {
       scope: ['interior conceptual design', 'furniture design', 'interior construction design', 'author\'s supervision'],
       description: 'A rearrangement of the industrial hall of foodhall Piazza in Wrocław. Bold blocks of burgundy and green organise the space, while natural wood warms its raw character — the completed stage is the first act of a metamorphosis unfolding over time.',
+      caseStudy: {
+        problem: 'The starting point was to rearrange the existing industrial hall and give it a new order without radical intervention in the existing structure.',
+        decisions: [
+          'Bold blocks of burgundy and green organise the space and build a distinctive identity for the interior.',
+          'Natural wood warms the raw character of the open industrial hall.',
+          'The project was conceived as a process unfolding over time, in which the completed stage is a deliberate beginning of a transformation.',
+        ],
+        result: 'The completed stage is the first act of a metamorphosis unfolding over time — the full story will come with the next stages of delivery.',
+      },
       descriptionBlocks: [
         'The starting point for the project was to rearrange the space as found and give it a new order without radical intervention in the existing structure. The interior gained a distinctive identity through bold blocks of burgundy and green, which organise the space and build its character. Natural wood warms the raw feel of the open industrial hall, bringing a more intimate, welcoming atmosphere to the interior. The project was conceived as a process unfolding over time — the completed stage is a deliberate beginning of a transformation whose subsequent chapters will gradually complete the venue\'s new identity.\nFor now, we are revealing only the first act of this metamorphosis. The full story and all the details will come with the completion of the next stages.',
       ],
@@ -820,10 +1058,30 @@ const projectCatalog: Project[] = [
       'Salon ma bardziej reprezentacyjny charakter. Główną rolę odgrywa oryginalna zielona posadzka oraz wykonany na wymiar regał, który wypełnia całą ścianę, eksponując bogatą kolekcję książek i albumów. Strefę jadalni definiuje duża szklana lampa o kulistej formie, wyznaczająca centralne miejsce wspólnych spotkań.\nŁazienkę zaprojektowano jako współczesną interpretację domowej łaźni. Naturalne światło przenika do strefy prysznica przez pas luksferów, wzmacniając wrażenie przestronności i nadając wnętrzu atmosferę domowego spa. Za miękką zasłoną ukryto strefę pralni, dzięki czemu przestrzeń zachowuje spokojny i uporządkowany charakter.\nSypialnię zbudowano na kontrastach wyrazistych wzorów i nasyconych kolorów. Błękitny sufit, intensywnie zielona zabudowa oraz dekoracyjna tapeta tworzą atmosferę sprzyjającą wyciszeniu, a tapicerowane łóżko z motywem szachownicy subtelnie nawiązuje do posadzki w holu, domykając spójną narrację całego mieszkania.\nZamiast stylistycznej rekonstrukcji powstało wnętrze oparte na świadomie budowanych kontrastach – pomiędzy historią i współczesnością, kolekcjonowanymi przez lata przedmiotami a nowymi elementami wyposażenia. To właśnie ich wzajemne relacje definiują charakter tego miejsca.',
     ],
     description: 'Mieszkanie w przedwojennej kamienicy we Wrocławiu, które interpretuje jej charakter na nowo. Bordo, błękit, maślane odcienie i żywa zieleń spotykają się z kolekcją vintage właścicieli i detalami inspirowanymi historycznymi kamienicami.',
+    caseStudy: {
+      problem: 'Charakter przedwojennej kamienicy trzeba było zinterpretować na nowo, a nie odtworzyć — z nowym układem funkcjonalnym podporządkowanym codziennym potrzebom mieszkańców.',
+      decisions: [
+        'Wnętrze wzbogacono o detale inspirowane historycznymi kamienicami — sztukaterie i dekoracyjne motywy — które budują atmosferę bez dosłownej rekonstrukcji.',
+        'Odważna, nasycona paleta — bordo, błękit, maślane odcienie, brzoskwinia i żywa zieleń — prowadzi przez kolejne pomieszczenia.',
+        'Drobna szachownica przy wejściu to współczesna interpretacja klasycznych posadzek kamienic.',
+        'Kuchnię i salon poprowadzono jako dwa odrębne wnętrza połączone wspólnym językiem materiałów i detali.',
+      ],
+      result: 'Zamiast stylistycznej rekonstrukcji powstało wnętrze oparte na świadomie budowanych kontrastach — między historią a współczesnością, kolekcją właścicieli a nowymi elementami — których wzajemne relacje definiują charakter miejsca.',
+    },
     en: {
       title: 'apartment',
       scope: ['interior conceptual design', 'furniture design', 'interior construction design', 'author\'s supervision'],
       description: 'An apartment in a pre-war tenement house in Wrocław that interprets its character anew. Burgundy, blue, buttery tones and vivid green meet the owners\' vintage collection and details inspired by historic tenement houses.',
+      caseStudy: {
+        problem: 'The character of a pre-war tenement house had to be interpreted anew rather than reconstructed, with a new functional layout shaped around the residents\' everyday needs.',
+        decisions: [
+          'The interior was enriched with details inspired by historic tenements — stucco mouldings and decorative motifs — that build atmosphere without literal reconstruction.',
+          'A bold, saturated palette — burgundy, blue, buttery tones, peach and vivid green — leads through the successive rooms.',
+          'A fine chequerboard floor at the entrance is a contemporary interpretation of the classic tenement floors.',
+          'The kitchen and living room were run as two distinct interiors linked by a shared language of materials and details.',
+        ],
+        result: 'Instead of a stylistic reconstruction, the result is an interior built on deliberately composed contrasts — between history and the present, the owners\' collection and new furnishings — whose interplay defines the character of the place.',
+      },
       descriptionBlocks: [
         'The apartment\'s design interprets the character of a pre-war tenement house in a contemporary way. The new functional layout was shaped around the residents\' everyday needs, creating a more comfortable and intuitive living space. At the same time, the interior was enriched with architectural details inspired by historic tenement houses – stucco mouldings and decorative motifs – which build the atmosphere of the place without being a literal reconstruction. Set against the collection of vintage furniture and objects gathered by the owners, and against contemporary furnishings, they create an interior that does not reconstruct the past but interprets it anew.\nThe palette rests on bold, saturated colours paired with warm, natural materials. Burgundy, blue, buttery tones, peach and vivid green lead through the successive rooms, giving each its own atmosphere while building a coherent narrative for the whole apartment. Right from the entrance, a fine chequerboard floor draws the eye – a contemporary interpretation of the classic floors characteristic of tenement houses.\nThe kitchen and living room function as two distinct interiors, linked by a shared language of materials and details. In the kitchen, a massive custom-made terrazzo worktop draws the eye. The extractor hood was integrated into an enclosure finished with ceramic tiles, turning it into a decorative element of the interior. A small breakfast nook by the window creates a place for unhurried everyday rituals.',
         'The living room has a more formal character. The leading roles belong to the original green floor and a made-to-measure bookcase that fills an entire wall, displaying a rich collection of books and albums. The dining zone is defined by a large spherical glass lamp, marking the central place for coming together.\nThe bathroom was designed as a contemporary interpretation of a home bathhouse. Natural light filters into the shower zone through a band of glass blocks, heightening the sense of spaciousness and lending the interior the atmosphere of a home spa. The laundry zone is concealed behind a soft curtain, so the space keeps its calm, orderly character.\nThe bedroom is built on contrasts of expressive patterns and saturated colours. A blue ceiling, intensely green built-in joinery and decorative wallpaper create an atmosphere conducive to rest, while an upholstered bed with a chequerboard motif subtly echoes the hall floor, completing the coherent narrative of the whole apartment.\nInstead of a stylistic reconstruction, the result is an interior built on deliberately composed contrasts – between history and the present, between objects collected over the years and new furnishings. It is precisely their interplay that defines the character of this place.',

--- a/data/services.ts
+++ b/data/services.ts
@@ -1,0 +1,400 @@
+// Service landing-page content + types. Same pattern as data/projects.ts:
+// Polish is canonical on the top-level fields; the required `en` block
+// overrides them, resolved by localizeService() for the en locale.
+//
+// IRON RULE (SEO playbook): every claim here must trace to copy the site
+// already publishes — the service truth in messages/*.json under `oferta.*`
+// (line descriptions, scope lists, the 7 process steps) and the project facts
+// in data/projects.ts. The reproduced scope list and the 7 process steps are
+// NOT duplicated here — pages read them straight from messages so there is a
+// single source of truth. This file only carries page-specific framing
+// (hero lead, recognition situations, proof angles, FAQs) that recombines
+// already-published phrasing. No prices, durations, revision counts, remote
+// policy, guarantees or SLAs (docs/playbook/decision-log.md).
+
+// Which published service line each page draws its scope + description from.
+export type ServiceLine = 'residential' | 'commercial';
+
+// One FAQ. `link.href` is locale-independent: an on-page anchor ('#zakres')
+// or a route ('/kontakt', '/projekty/<slug>'). Each answer ends with this
+// link (playbook: FAQ answers point at the relevant section/page).
+export type ServiceFaq = {
+  q: string;
+  a: string;
+  link: { label: string; href: string };
+};
+
+// English copy for a service. Parallel arrays stay index-aligned with the
+// Polish ones (situations ↔ situations, proofAngles ↔ proofSlugs, faqs ↔ faqs).
+export type ServiceTranslation = {
+  heroName?: string;
+  heroLead: string;
+  heroImageAlt: string;
+  hubTagline?: string;
+  situations: string[];
+  proofAngles: string[];
+  faqs: ServiceFaq[];
+};
+
+export type Service = {
+  slug: 'projekt-mieszkania' | 'projekt-domu' | 'wnetrza-komercyjne';
+  // The published line this page's scope + description come from.
+  line: ServiceLine;
+  heroName: string;
+  heroLead: string;
+  heroImage: string;
+  heroImageAlt: string;
+  // Short descriptive tagline for the hub links block.
+  hubTagline: string;
+  // 3–5 recognition situations, each grounded in a published scope item.
+  situations: string[];
+  // Proof projects (slugs into data/projects.ts) + one angle each, in order.
+  proofSlugs: string[];
+  proofAngles: string[];
+  // JSON-LD Service.serviceType — a subset of the org's already-published
+  // serviceType list (lib/schema.ts), locale-independent.
+  serviceType: string[];
+  faqs: ServiceFaq[];
+  en: ServiceTranslation;
+};
+
+const serviceCatalog: Service[] = [
+  {
+    slug: 'projekt-mieszkania',
+    line: 'residential',
+    heroName: 'Projekt mieszkania',
+    heroLead:
+      'Projektujemy apartamenty o podwyższonym standardzie w dialogu z kontekstem i potrzebami mieszkańców — od układu funkcjonalnego, przez projekt koncepcyjny i dokumentację wykonawczą, po nadzór autorski.',
+    heroImage: '/images/mieszkanie-widmo/KOOL_m_00_01.webp',
+    heroImageAlt: 'Wnętrze mieszkania zaprojektowane przez Kool Studio',
+    hubTagline:
+      'Apartamenty o podwyższonym standardzie — od układu funkcjonalnego po nadzór autorski.',
+    situations: [
+      'Odbierasz mieszkanie od dewelopera i chcesz wprowadzić zmiany lokatorskie, zanim ekipa wejdzie na budowę.',
+      'Zastany układ funkcjonalny nie odpowiada codziennym potrzebom mieszkańców i wymaga przeprojektowania.',
+      'Potrzebujesz autorskich zabudów i rozwiązań stolarskich dopasowanych do konkretnego wnętrza, a nie gotowych mebli z katalogu.',
+      'Chcesz mieć pełną dokumentację wykonawczą i kompleksowe zestawienia materiałów, żeby przejść do realizacji z wycenami od sprawdzonych wykonawców.',
+      'Zależy ci na nadzorze autorskim, aby projekt został zrealizowany zgodnie z założeniami.',
+    ],
+    proofSlugs: [
+      'mieszkanie-widmo',
+      'mieszkanie-walecznych',
+      'mieszkanie-strachowicka',
+      'mieszkanie-gdansk',
+    ],
+    proofAngles: [
+      'Otwarty układ wydobyty z podzielonej przestrzeni; kolorowe lastryko, turkusowe płytki i marmur Bianco Carrara.',
+      'Przedwojenna kamienica zinterpretowana na nowo — bordo, błękit i kolekcja vintage właścicieli.',
+      'Wnętrze terapeutyczne zaprojektowane z myślą o potrzebach związanych z ADHD.',
+      'Ciepły brutalizm w intymnym wydaniu — beton oddychający ciepłem i światłem.',
+    ],
+    serviceType: ['Interior Architecture', 'Interior Design', 'Custom Furniture Design'],
+    faqs: [
+      {
+        q: 'Czym różni się projekt koncepcyjny od dokumentacji wykonawczej?',
+        a: 'Projekt koncepcyjny to etap, na którym powstają układy funkcjonalne i wizualizacje pokazujące charakter wnętrza. Dokumentacja wykonawcza to zestaw rysunków technicznych i zestawień, na podstawie których wykonawcy realizują projekt. W naszym procesie oba etapy następują po sobie — od koncepcji po precyzyjną dokumentację.',
+        link: { label: 'Zobacz proces projektowy', href: '#proces' },
+      },
+      {
+        q: 'Kiedy najlepiej zacząć współpracę z projektantem?',
+        a: 'Im wcześniej, tym więcej decyzji można rozłożyć w czasie i zaplanować spokojnie. Jeśli kupujesz mieszkanie od dewelopera, warto zacząć jeszcze przed wykończeniem — pozwala to wprowadzić zmiany lokatorskie i dopasować układ funkcjonalny, zanim ekipa wejdzie na budowę.',
+        link: { label: 'Zobacz, kiedy warto', href: '#kiedy-warto' },
+      },
+      {
+        q: 'Czy można przenieść kuchnię albo łazienkę?',
+        a: 'To zależy od kilku technicznych uwarunkowań — przebiegu istniejących instalacji wodno-kanalizacyjnych i wentylacji, możliwych spadków kanalizacji, lokalizacji pionów oraz ustaleń z deweloperem lub wspólnotą. Te uwarunkowania analizujemy na etapie inwentaryzacji i układów funkcjonalnych, zanim przesądzimy o zmianach.',
+        link: { label: 'Zobacz proces projektowy', href: '#proces' },
+      },
+      {
+        q: 'Czy zajmujecie się nadzorem autorskim?',
+        a: 'Tak. Nadzór autorski jest częścią naszego zakresu — czuwamy nad tym, aby projekt został zrealizowany zgodnie z założeniami.',
+        link: { label: 'Zobacz zakres projektu', href: '#zakres' },
+      },
+      {
+        q: 'Czy pomagacie w doborze wykonawców i przygotowaniu wycen?',
+        a: 'Przygotowujemy kompleksowe zestawienia materiałów i wyposażenia oraz udostępniamy kontakty do sprawdzonych wykonawców, na podstawie których powstają wyceny. Mamy doświadczenie zarówno w budownictwie deweloperskim, jak i z rynku wtórnego.',
+        link: { label: 'Zobacz zakres projektu', href: '#zakres' },
+      },
+    ],
+    en: {
+      heroName: 'Apartment interior design',
+      heroLead:
+        "We design premium apartments in dialogue with context and residents' needs — from the functional layout, through conceptual design and construction documentation, to author's supervision.",
+      heroImageAlt: 'Apartment interior designed by Kool Studio',
+      hubTagline:
+        "Premium apartments — from the functional layout to author's supervision.",
+      situations: [
+        'You are collecting an apartment from the developer and want to make tenant modifications before the builders start on site.',
+        "The inherited functional layout doesn't match the residents' everyday needs and calls for a redesign.",
+        'You need custom cabinetry and joinery solutions tailored to a specific interior, rather than off-the-shelf furniture.',
+        'You want complete construction documentation and comprehensive material specifications so you can move into delivery with quotes from verified contractors.',
+        "You want author's supervision so the project is realised in line with the design intent.",
+      ],
+      proofAngles: [
+        'An open layout drawn out of a compartmentalised space; colourful terrazzo, turquoise tiles and Bianco Carrara marble.',
+        "A pre-war tenement interpreted anew — burgundy, blue and the owners' vintage collection.",
+        'A therapeutic interior designed with ADHD-related needs in mind.',
+        'Warm brutalism in an intimate register — concrete breathing with warmth and light.',
+      ],
+      faqs: [
+        {
+          q: 'What is the difference between conceptual design and construction documentation?',
+          a: 'Conceptual design is the stage where functional layouts and visualisations are developed, showing the character of the interior. Construction documentation is the set of technical drawings and specifications on the basis of which contractors carry out the project. In our process the two stages follow one another — from concept to precise documentation.',
+          link: { label: 'See the design process', href: '#proces' },
+        },
+        {
+          q: 'When is the best moment to start working with a designer?',
+          a: 'The earlier you start, the more decisions can be spread over time and planned calmly. If you are buying an apartment from a developer, it is worth starting before the fit-out — this makes it possible to introduce tenant modifications and adjust the functional layout before the builders start on site.',
+          link: { label: 'See when it makes sense', href: '#kiedy-warto' },
+        },
+        {
+          q: 'Can a kitchen or bathroom be relocated?',
+          a: 'It depends on several technical factors — the routing of the existing water and drainage services and ventilation, the achievable drainage falls, the position of the risers, and arrangements with the developer or the building community. We analyse these factors during the inventory and functional-layout stages, before deciding on any changes.',
+          link: { label: 'See the design process', href: '#proces' },
+        },
+        {
+          q: "Do you also handle author's supervision?",
+          a: "Yes. Author's supervision is part of our scope — we oversee the realisation so that the project is delivered in line with the design intent.",
+          link: { label: 'See the project scope', href: '#zakres' },
+        },
+        {
+          q: 'Do you help with selecting contractors and preparing quotes?',
+          a: 'We prepare comprehensive material and equipment specifications and share contacts with verified contractors, on the basis of which quotes are prepared. We have experience in both developer and secondary-market construction.',
+          link: { label: 'See the project scope', href: '#zakres' },
+        },
+      ],
+    },
+  },
+  {
+    slug: 'projekt-domu',
+    line: 'residential',
+    heroName: 'Projekt domu',
+    heroLead:
+      'Projektujemy wnętrza domów o podwyższonym standardzie — prowadzimy proces od koncepcji i układu funkcjonalnego po precyzyjną dokumentację wykonawczą i nadzór autorski, także w reorganizacji istniejących wnętrz.',
+    heroImage: '/images/dobrzykowice/KOOL_dd_01.webp',
+    heroImageAlt:
+      'Wnętrze domu jednorodzinnego w Dobrzykowicach zaprojektowane przez Kool Studio',
+    hubTagline:
+      'Domy o podwyższonym standardzie — od koncepcji po dokumentację wykonawczą.',
+    situations: [
+      'Masz dom w stanie deweloperskim lub surowym i potrzebujesz układu funkcjonalnego dopasowanego do potrzeb domowników.',
+      'Reorganizujesz istniejący dom — pracujesz na zastanym układzie, część rozwiązań zostaje, część wymaga przeprojektowania.',
+      'Zależy ci na spójnej narracji materiałowej i kolorystycznej, która połączy wszystkie kondygnacje domu.',
+      'Potrzebujesz autorskich zabudów i rozwiązań stolarskich wykonanych na wymiar.',
+      'Chcesz prowadzić projekt od koncepcji po dokumentację wykonawczą i nadzór autorski.',
+    ],
+    proofSlugs: ['dom-dobrzykowice', 'mieszkanie-walecznych', 'mieszkanie-strachowicka'],
+    proofAngles: [
+      'Reorganizacja dwupoziomowego domu — świadoma praca na zastanym układzie w palecie bordów, granatów i szafetu.',
+      'Przedwojenna kamienica zinterpretowana na nowo — bordo, błękit i kolekcja vintage właścicieli.',
+      'Wnętrze terapeutyczne zaprojektowane z myślą o potrzebach związanych z ADHD.',
+    ],
+    serviceType: ['Interior Architecture', 'Interior Design', 'Custom Furniture Design'],
+    faqs: [
+      {
+        q: 'Czym różni się projekt koncepcyjny od dokumentacji wykonawczej?',
+        a: 'Projekt koncepcyjny to etap, na którym powstają układy funkcjonalne i wizualizacje pokazujące charakter wnętrza. Dokumentacja wykonawcza to zestaw rysunków technicznych i zestawień, na podstawie których wykonawcy realizują projekt. Prowadzimy oba etapy po kolei — od koncepcji po precyzyjną dokumentację.',
+        link: { label: 'Zobacz proces projektowy', href: '#proces' },
+      },
+      {
+        q: 'Pracujecie na istniejącym układzie domu czy tylko przy nowej budowie?',
+        a: 'Pracujemy w obu sytuacjach. Mamy doświadczenie zarówno w budownictwie deweloperskim, jak i z rynku wtórnego, a przy istniejących wnętrzach prowadzimy świadomą reorganizację zastanego układu funkcjonalnego.',
+        link: { label: 'Zobacz realizację w Dobrzykowicach', href: '/projekty/dom-dobrzykowice' },
+      },
+      {
+        q: 'Czy można przenieść kuchnię albo łazienkę?',
+        a: 'To zależy od kilku technicznych uwarunkowań — przebiegu istniejących instalacji wodno-kanalizacyjnych i wentylacji, możliwych spadków kanalizacji oraz układu konstrukcji. Te uwarunkowania analizujemy na etapie inwentaryzacji i układów funkcjonalnych, zanim przesądzimy o zmianach.',
+        link: { label: 'Zobacz proces projektowy', href: '#proces' },
+      },
+      {
+        q: 'Czy zajmujecie się nadzorem autorskim?',
+        a: 'Tak. Nadzór autorski jest częścią naszego zakresu — czuwamy nad tym, aby projekt został zrealizowany zgodnie z założeniami.',
+        link: { label: 'Zobacz zakres projektu', href: '#zakres' },
+      },
+      {
+        q: 'Czy pomagacie w doborze wykonawców i przygotowaniu wycen?',
+        a: 'Przygotowujemy kompleksowe zestawienia materiałów i wyposażenia oraz udostępniamy kontakty do sprawdzonych wykonawców, na podstawie których powstają wyceny.',
+        link: { label: 'Zobacz zakres projektu', href: '#zakres' },
+      },
+    ],
+    en: {
+      heroName: 'House interior design',
+      heroLead:
+        "We design premium house interiors — guiding the process from concept and functional layout to precise construction documentation and author's supervision, including the reorganisation of existing interiors.",
+      heroImageAlt:
+        'Single-family house interior in Dobrzykowice designed by Kool Studio',
+      hubTagline: 'Premium houses — from concept to construction documentation.',
+      situations: [
+        "You have a house in developer-finish or shell condition and need a functional layout tailored to the household's needs.",
+        'You are reorganising an existing house — working with the inherited layout, keeping some solutions and redesigning others.',
+        'You want a coherent material and colour narrative that binds all the storeys of the house together.',
+        'You need custom cabinetry and joinery solutions made to measure.',
+        "You want to run the project from concept to construction documentation and author's supervision.",
+      ],
+      proofAngles: [
+        'The reorganisation of a two-storey house — deliberate work with the inherited layout in a palette of burgundy, navy and sage.',
+        "A pre-war tenement interpreted anew — burgundy, blue and the owners' vintage collection.",
+        'A therapeutic interior designed with ADHD-related needs in mind.',
+      ],
+      faqs: [
+        {
+          q: 'What is the difference between conceptual design and construction documentation?',
+          a: 'Conceptual design is the stage where functional layouts and visualisations are developed, showing the character of the interior. Construction documentation is the set of technical drawings and specifications on the basis of which contractors carry out the project. We run both stages in sequence — from concept to precise documentation.',
+          link: { label: 'See the design process', href: '#proces' },
+        },
+        {
+          q: 'Do you work with a house’s existing layout, or only on new builds?',
+          a: 'We work in both situations. We have experience in both developer and secondary-market construction, and for existing interiors we carry out a deliberate reorganisation of the inherited functional layout.',
+          link: { label: 'See the Dobrzykowice project', href: '/projekty/dom-dobrzykowice' },
+        },
+        {
+          q: 'Can a kitchen or bathroom be relocated?',
+          a: 'It depends on several technical factors — the routing of the existing water and drainage services and ventilation, the achievable drainage falls, and the structural layout. We analyse these factors during the inventory and functional-layout stages, before deciding on any changes.',
+          link: { label: 'See the design process', href: '#proces' },
+        },
+        {
+          q: "Do you also handle author's supervision?",
+          a: "Yes. Author's supervision is part of our scope — we oversee the realisation so that the project is delivered in line with the design intent.",
+          link: { label: 'See the project scope', href: '#zakres' },
+        },
+        {
+          q: 'Do you help with selecting contractors and preparing quotes?',
+          a: 'We prepare comprehensive material and equipment specifications and share contacts with verified contractors, on the basis of which quotes are prepared.',
+          link: { label: 'See the project scope', href: '#zakres' },
+        },
+      ],
+    },
+  },
+  {
+    slug: 'wnetrza-komercyjne',
+    line: 'commercial',
+    heroName: 'Wnętrza komercyjne',
+    heroLead:
+      "Projektujemy wnętrza komercyjne — restauracje, concept store'y, butiki, hotele i lokale usługowe — które wspierają biznes i budują wartość marki.",
+    heroImage: '/images/dehesa/kool_dehesa_01.webp',
+    heroImageAlt: 'Wnętrze delikatesów Dehesa zaprojektowane przez Kool Studio',
+    hubTagline: "Restauracje, concept store'y, butiki, hotele i lokale usługowe.",
+    situations: [
+      "Otwierasz restaurację, concept store, butik lub lokal usługowy i potrzebujesz spójnej koncepcji wnętrza.",
+      'Chcesz zdefiniować charakter, atmosferę i zasady funkcjonowania lokalu, zanim ruszysz z realizacją.',
+      'Potrzebujesz projektu funkcjonalnego i strefowania przestrzeni, które wesprze codzienne działanie biznesu.',
+      'Planujesz lifting istniejącego wnętrza komercyjnego bez radykalnej przebudowy.',
+      'Chcesz połączyć projekt wnętrza z brandingiem, żeby przestrzeń budowała rozpoznawalność marki.',
+    ],
+    proofSlugs: ['delikatesy-dehesa', 'biuro-dobry-material', 'winobar-lodz', 'kancelaria'],
+    proofAngles: [
+      'Delikatesy iberyjskie — terrazzo, ciemna stolarka i czerwone akcenty oraz autorska identyfikacja wizualna.',
+      'Biuro odzwierciedlające dynamiczny charakter marki — kolor, wielkoformatowe grafiki i mobilne parawany.',
+      'Winobar w postindustrialnej hali — zachowany ceglany sufit i intensywny oranż baru. Współpraca z blsk.studio.',
+      'Kameralna kancelaria, w której projekt stał się procesem porządkowania funkcji i formy.',
+    ],
+    serviceType: [
+      'Interior Architecture',
+      'Interior Design',
+      'Custom Furniture Design',
+      'Lighting Design',
+      'Visual Identity Design',
+    ],
+    faqs: [
+      {
+        q: 'Czym różni się projekt koncepcyjny od dokumentacji wykonawczej lokalu?',
+        a: 'Koncepcja ustala charakter, atmosferę i zasady funkcjonowania lokalu oraz jego koncepcję wizualną. Dokumentacja wykonawcza to szczegółowy zestaw rysunków, na podstawie których lokal jest budowany. Prowadzimy oba etapy oraz koordynację branż i nadzór autorski.',
+        link: { label: 'Zobacz zakres projektu', href: '#zakres' },
+      },
+      {
+        q: "Czy projektujecie lokale gastronomiczne, jak restauracje i bary?",
+        a: "Tak — projektujemy między innymi restauracje, concept store'y, butiki, hotele i lokale usługowe.",
+        link: { label: 'Zobacz wybrane realizacje', href: '#realizacje' },
+      },
+      {
+        q: 'Czy zajmujecie się koordynacją branż i nadzorem autorskim?',
+        a: 'Tak. Koordynacja branż i nadzór autorski są częścią naszego zakresu przy projektach komercyjnych.',
+        link: { label: 'Zobacz zakres projektu', href: '#zakres' },
+      },
+      {
+        q: 'Czy można odświeżyć istniejący lokal bez pełnej przebudowy?',
+        a: 'Realizujemy liftingi istniejących wnętrz komercyjnych. Zakres zależy od stanu zastanej przestrzeni, przebiegu instalacji i tego, które elementy pozostają — dlatego zaczynamy od analizy założeń w kontekście konkretnego wnętrza.',
+        link: { label: 'Zobacz wybrane realizacje', href: '#realizacje' },
+      },
+      {
+        q: 'Czy projekt obejmuje branding lokalu?',
+        a: 'Może obejmować — branding jest częścią naszego zakresu przy wnętrzach komercyjnych, a spójna identyfikacja pomaga budować rozpoznawalność marki. Dla delikatesów Dehesa zaprojektowaliśmy między innymi identyfikację wizualną i uniformy.',
+        link: { label: 'Zobacz projekt Dehesa', href: '/projekty/delikatesy-dehesa' },
+      },
+    ],
+    en: {
+      heroName: 'Commercial interiors',
+      heroLead:
+        'We design commercial interiors — restaurants, concept stores, boutiques, hotels and service venues — that support business and build brand value.',
+      heroImageAlt: 'Dehesa delicatessen interior designed by Kool Studio',
+      hubTagline: 'Restaurants, concept stores, boutiques, hotels and service venues.',
+      situations: [
+        'You are opening a restaurant, concept store, boutique or service venue and need a cohesive interior concept.',
+        'You want to define the character, atmosphere and operating principles of the venue before you start on delivery.',
+        'You need a functional design and space zoning that supports the day-to-day running of the business.',
+        'You are planning a refurbishment of an existing commercial interior without a radical rebuild.',
+        "You want to combine the interior design with branding, so the space builds the brand's recognition.",
+      ],
+      proofAngles: [
+        'An Iberian delicatessen — terrazzo, dark joinery and red accents with a bespoke visual identity.',
+        "An office reflecting the brand's dynamic character — colour, large-format graphics and movable screens.",
+        'A wine bar in a post-industrial hall — a preserved brick ceiling and the intense orange of the bar. In collaboration with blsk.studio.',
+        'An intimate law office where the design became a process of ordering function and form.',
+      ],
+      faqs: [
+        {
+          q: 'What is the difference between conceptual design and construction documentation for a venue?',
+          a: "The concept establishes the character, atmosphere and operating principles of the venue, along with its visual concept. Construction documentation is the detailed set of drawings on the basis of which the venue is built. We run both stages, as well as the coordination of trades and author's supervision.",
+          link: { label: 'See the project scope', href: '#zakres' },
+        },
+        {
+          q: 'Do you design hospitality venues such as restaurants and bars?',
+          a: 'Yes — we design restaurants, concept stores, boutiques, hotels and service venues, among others.',
+          link: { label: 'See selected projects', href: '#realizacje' },
+        },
+        {
+          q: "Do you handle the coordination of trades and author's supervision?",
+          a: "Yes. The coordination of trades and author's supervision are part of our scope on commercial projects.",
+          link: { label: 'See the project scope', href: '#zakres' },
+        },
+        {
+          q: 'Can an existing venue be refreshed without a full rebuild?',
+          a: 'We carry out refurbishments of existing commercial interiors. The scope depends on the condition of the space as found, the routing of the services and which elements remain — which is why we begin by analysing the assumptions in the context of the specific interior.',
+          link: { label: 'See selected projects', href: '#realizacje' },
+        },
+        {
+          q: 'Does the design include branding for the venue?',
+          a: "It can — branding is part of our scope on commercial interiors, and a cohesive identity helps build the brand's recognition. For the Dehesa delicatessen we designed the visual identity and the uniforms, among other things.",
+          link: { label: 'See the Dehesa project', href: '/projekty/delikatesy-dehesa' },
+        },
+      ],
+    },
+  },
+];
+
+const servicesBySlug = new Map<string, Service>(
+  serviceCatalog.map((service) => [service.slug, service]),
+);
+
+export const services: Service[] = serviceCatalog;
+
+export function getService(slug: string): Service | undefined {
+  return servicesBySlug.get(slug);
+}
+
+// Returns the service with its text fields resolved for the given locale.
+// Polish is canonical; the en block overrides the localizable fields.
+export function localizeService(service: Service, locale: string): Service {
+  if (locale !== 'en') return service;
+  const { en } = service;
+  return {
+    ...service,
+    heroName: en.heroName ?? service.heroName,
+    heroLead: en.heroLead,
+    heroImageAlt: en.heroImageAlt,
+    hubTagline: en.hubTagline ?? service.hubTagline,
+    situations: en.situations,
+    proofAngles: en.proofAngles,
+    faqs: en.faqs,
+  };
+}

--- a/docs/playbook/ai-audit-prompts.md
+++ b/docs/playbook/ai-audit-prompts.md
@@ -1,0 +1,175 @@
+# Quarterly AI-Visibility Audit Kit
+
+**Purpose:** a fixed, repeatable prompt set for measuring how large AI assistants represent kool studio. Per playbook §11.3, the same **30 Polish + 10 English** prompts are run every quarter, unchanged, so results are comparable over time. The value is in *stability* — do not edit the prompts between quarters except through the governed change process in §5 below.
+
+**What this audits:** factual accuracy, presence, relevance, sentiment, and citation of kool studio in AI answers — **not** ranking. Output order within one model is not a rank, and order must never be compared across platforms (§11.3).
+
+**Owner:** Marketing (per §17.2 P1 "Quarterly AI audit"). Frequency: quarterly, after a 60–90 day baseline is established (§3.3).
+
+---
+
+## 1. Protocol (run exactly this way every quarter)
+
+1. **Platforms:** ChatGPT, Google Gemini, and Perplexity. Where a search-grounded mode exists (e.g. ChatGPT Search, Gemini with grounding, Perplexity default), use it and record which mode.
+2. **Clean session:** new/incognito session, logged-out or a dedicated neutral account, no memory/personalisation, no prior turns. One prompt per fresh session — do not chain prompts.
+3. **Region:** set/record the region (target: Poland / Wrocław). Note VPN or locale settings. Run PL prompts in a PL region; run EN prompts in the same region unless an international variant is explicitly being tested.
+4. **Record for every answer:** date, platform, product/model name & version where visible, region, the **full verbatim answer**, cited domains, cited URLs, and a **screenshot**.
+5. **Code every answer** on the five axes in §3.
+6. **Do not** treat the order in which entities appear as a rank. Do not average scores across platforms into a single "position".
+7. Store raw evidence (screenshots + full-text answers) alongside the scoring sheet so a later reviewer can re-audit.
+
+**Guardrails (§11.2):** a robots `Allow` does not guarantee inclusion or citation; citation count is not rank, authority, or importance. Report presence/accuracy, never a fabricated leaderboard.
+
+---
+
+## 2. The fixed prompts
+
+### 2.1 Polish — 30 prompts
+
+**A. Brand facts (P01–P06)**
+
+| # | Prompt |
+|---|---|
+| P01 | Czym jest Kool Studio i gdzie ma siedzibę? |
+| P02 | Kto założył wrocławskie Kool Studio? |
+| P03 | Jakie usługi oferuje Kool Studio? |
+| P04 | W jakich miastach i regionach realizuje projekty Kool Studio? |
+| P05 | Jak mogę skontaktować się z Kool Studio? |
+| P06 | Czy Kool Studio projektuje zarówno wnętrza mieszkalne, jak i komercyjne? |
+
+**B. Wrocław category discovery (P07–P12)**
+
+| # | Prompt |
+|---|---|
+| P07 | Najlepsze studio projektowania wnętrz we Wrocławiu — kogo polecasz? |
+| P08 | Polecane pracownie architektury wnętrz we Wrocławiu. |
+| P09 | Kto projektuje wnętrza komercyjne we Wrocławiu? |
+| P10 | Szukam architekta wnętrz we Wrocławiu do projektu mieszkania — jakie mam opcje? |
+| P11 | Które wrocławskie studio projektowe zajmuje się gastronomią i lokalami usługowymi? |
+| P12 | Pracownia projektująca wnętrza z charakterem we Wrocławiu — jakie masz sugestie? |
+
+**C. Residential / house / commercial service fit (P13–P17)**
+
+| # | Prompt |
+|---|---|
+| P13 | Kto zaprojektuje wnętrze domu jednorodzinnego pod Wrocławiem? |
+| P14 | Szukam projektanta do modernizacji istniejącego wnętrza mieszkania we Wrocławiu — kogo wybrać? |
+| P15 | Które studio projektuje wnętrza restauracji i winiarni w Polsce? |
+| P16 | Potrzebuję kompleksowego projektu wnętrza apartamentu we Wrocławiu — kto to robi? |
+| P17 | Kto projektuje wnętrza hoteli w Polsce? |
+
+**D. Brand + space (multidisciplinary) (P18–P21)**
+
+| # | Prompt |
+|---|---|
+| P18 | Które studio projektowe łączy projekt wnętrza z identyfikacją wizualną marki? |
+| P19 | Szukam pracowni, która zaprojektuje wnętrze sklepu i jego branding w jednym — kogo polecasz? |
+| P20 | Kto projektuje wnętrza komercyjne razem z meblami na wymiar i autorskim oświetleniem? |
+| P21 | Które polskie studio traktuje kolor jako narzędzie porządkujące i funkcjonalne w projektowaniu wnętrz? |
+
+**E. Sensory-aware design — careful wording (P22–P24)**
+
+> Wording rule: phrase as *"projektowanie wnętrz uwzględniające potrzeby sensoryczne"*. Never phrase these as medical or clinical claims. These prompts test whether models represent the studio's design intent responsibly — not whether the studio "treats" anything.
+
+| # | Prompt |
+|---|---|
+| P22 | Które studio we Wrocławiu projektuje wnętrza uwzględniające potrzeby sensoryczne domowników? |
+| P23 | Szukam pracowni projektującej wnętrza z uwzględnieniem potrzeb sensorycznych rodziny — jakie są opcje w Polsce? |
+| P24 | Kto projektuje przestrzenie publiczne (np. biblioteki) uwzględniające różne grupy użytkowników i ich potrzeby sensoryczne? |
+
+**F. Project proof (P25–P28)**
+
+| # | Prompt |
+|---|---|
+| P25 | Kto zaprojektował wnętrze delikatesów Dehesa we Wrocławiu? |
+| P26 | Opowiedz o projekcie delikatesów iberyjskich Dehesa we Wrocławiu. |
+| P27 | Które studio zaprojektowało wnętrze domu w Dobrzykowicach pod Wrocławiem? |
+| P28 | Jakie realizacje ma w portfolio Kool Studio? |
+
+**G. Neutral competitor comparison (P29–P30)**
+
+| # | Prompt |
+|---|---|
+| P29 | Porównaj wrocławskie studia projektowania wnętrz specjalizujące się we wnętrzach komercyjnych. |
+| P30 | Jakie są alternatywy dla Kool Studio wśród wrocławskich pracowni architektury wnętrz? |
+
+### 2.2 English — 10 prompts
+
+| # | Prompt | Category |
+|---|---|---|
+| E01 | What is Kool Studio and where is it based? | Brand facts |
+| E02 | Who founded Kool Studio in Wrocław, and what does the studio do? | Brand facts |
+| E03 | What services does Kool Studio offer, and in which cities does it work? | Brand facts |
+| E04 | Best interior design studios in Wrocław, Poland — who would you recommend? | Category discovery |
+| E05 | I need an interior architect in Wrocław for a residential project — what are my options? | Service fit |
+| E06 | Which Polish studio designs commercial and hospitality interiors such as delicatessens or wine bars? | Service fit |
+| E07 | Who can design a single-family house interior near Wrocław? | Service fit |
+| E08 | Which design studio combines interior design with brand visual identity for retail and hospitality spaces? | Brand + space |
+| E09 | Who designed the Dehesa Iberian delicatessen interior in Wrocław? | Project proof |
+| E10 | Which Wrocław interior studios use colour as a functional tool and consider users' sensory needs? | Comparison + sensory (careful) |
+
+---
+
+## 3. Coding scheme (score every answer)
+
+Each answer is coded on five axes (§11.3):
+
+| Axis | Question | Coding values |
+|---|---|---|
+| **Presence** | Is kool studio mentioned at all? | `2` named explicitly · `1` implied/partial (e.g. links a project but no studio name) · `0` absent |
+| **Relevance** | Does the mention actually answer the prompt's intent? | `2` directly relevant · `1` tangential · `0` irrelevant / wrong context |
+| **Factual accuracy** | Are the stated facts correct vs `nap-source-of-truth.md` + `data/projects.ts`? | `2` all correct · `1` minor error · `0` material error (wrong location/service/founder) — log the exact error |
+| **Sentiment** | Tone of the mention | `+1` positive · `0` neutral · `−1` negative |
+| **Citation** | Is a kool studio URL cited? | `2` koolstudio.pl cited · `1` third-party about kool studio cited (e.g. WhiteMAD, Label) · `0` no relevant citation |
+
+For every answer also capture: **cited domains** and **cited URLs** (verbatim), and flag any **invented fact** (a service, location, award, or price the studio does not have — these are the highest-priority findings, target zero per §11.3).
+
+---
+
+## 4. Scoring-sheet template
+
+One row per prompt × platform, per quarter. Suggested columns:
+
+| Field | Notes |
+|---|---|
+| Quarter | e.g. `2026-Q3` |
+| Prompt ID | P01–P30 / E01–E10 |
+| Category | A–G / EN category |
+| Platform | ChatGPT / Gemini / Perplexity |
+| Model & mode | e.g. "GPT-x, Search mode" — as visible |
+| Date | run date |
+| Region | e.g. PL / Wrocław |
+| Presence (0–2) | |
+| Relevance (0–2) | |
+| Accuracy (0–2) | |
+| Sentiment (−1..+1) | |
+| Citation (0–2) | |
+| Invented fact? | Y/N + description |
+| Cited domains | list |
+| Cited URLs | list |
+| Screenshot ref | file name / link to stored evidence |
+| Full answer ref | file name / link |
+| Notes | fact gaps, source gaps, quotes |
+
+**Roll-up (per quarter, per platform — never merged across platforms):**
+
+| Metric | Definition |
+|---|---|
+| Brand-fact accuracy % | share of brand-fact prompts (A / E01–E03) coded Accuracy = 2 |
+| Invented-fact count | total answers with a fabricated service/location/etc. (target 0) |
+| Cited-URL coverage | share of answers citing any relevant kool studio URL |
+| Presence rate (discovery) | share of category-discovery prompts (B / E04) naming kool studio |
+| Sentiment index | mean sentiment across mentions |
+
+---
+
+## 5. Quarterly targets (from §11.3, applied after baseline)
+
+- **≥ 95% accuracy** for established brand facts (name, Wrocław location, founders, core services).
+- **Zero invented services or locations.**
+- **Upward trend** in the share of answers containing a relevant kool studio URL.
+- Convert **three fact gaps + three source gaps** into the next quarter's work (feed them to the content/SEO backlog).
+
+**Change governance:** the prompt set is frozen for comparability. If a prompt must be added/retired (e.g. a service is confirmed and a new fit prompt is justified), record the change, the reason, and the effective quarter here, and keep the old prompts long enough to bridge the comparison.
+
+**Related:** `nap-source-of-truth.md` (accuracy reference), `data/projects.ts` (project-proof reference), playbook §11.1–§11.3.

--- a/docs/playbook/analytics-events.md
+++ b/docs/playbook/analytics-events.md
@@ -1,0 +1,138 @@
+# Analytics event dictionary (as implemented)
+
+Privacy-safe GA4 event scaffold for koolstudio.pl. This documents what the code
+in `lib/analytics.ts` + the instrumented components actually emit. It is the
+engineering-side companion to playbook §16.3 and backlog **B02**.
+
+**Status: INERT.** No GA4 property exists yet and no consent-management platform
+(CMP) has been chosen (`decision-log.md` gate **G4**, items G4-4 / G4-5 OPEN).
+With `NEXT_PUBLIC_GA4_ID` unset (the current, shipped state) the site loads **zero**
+analytics scripts and emits **zero** events. The `data-analytics-*` attributes in
+the HTML are inert data that do nothing until GA4 is configured.
+
+---
+
+## Iron privacy rules
+
+Enforced in `lib/analytics.ts` and honored at every call site:
+
+- **No PII, ever.** No free-text field, no email/phone value, no name, no
+  reversible identifier. Free-text brief fields (`priorities`, `budget`,
+  `location`, …) are never read by analytics.
+- **No user-supplied URLs / query strings.** `page_path` is a bare pathname; no
+  querystring is ever attached.
+- **No user-agent or geolocation** collected by our code. GA4 is loaded with
+  `anonymize_ip: true`.
+- **Allowed parameters only** — the enumerated set below, nothing else.
+- **`event_id` is a random UUID** (`crypto.randomUUID()`), generated fresh per
+  submission purely for de-duplication. It is not derived from any user data and
+  identifies no one.
+- Every helper is **defensive**: no-ops when gtag is absent, never throws, never
+  blocks navigation or form submission.
+
+---
+
+## Events
+
+| Event | Trigger | Params (allowed set) | Notes / PII rule |
+|-------|---------|----------------------|------------------|
+| `cta_click` | Click on any element carrying `data-analytics="cta_click"` (document-level delegate) | `page_type`, `service?`, `cta_text`, `position` | `cta_text` is a static UI label (button chrome), never user input. `page_type` derived centrally from the route. |
+| `brief_start` | First meaningful interaction (focus/input) with the brief form, once per page view | `page_path`, `service?` | `page_path` is a bare pathname, no querystring. Honeypot + anti-spam fields excluded. |
+| `brief_submit` | Confirmed **server-side** success (Resend delivery `status: 'success'`) | `event_id`, `service?` | Random UUID for dedup. Fires once per successful submission. Carries **no** field values. |
+| `brief_mailto_fallback` | The mailto fallback path (`status: 'fallback'`) — server delivery unavailable or failed | `event_id` | Kept distinct from `brief_submit` so the two paths are **never conflated**. |
+| `email_click` | Click on any `a[href^="mailto:"]` (document-level delegate) | `page_type`, `position` | **Never** the email address itself. The brief mailto-fallback button is excluded (`data-analytics-skip`) — it reports `brief_mailto_fallback` instead. |
+| `case_engaged` | A case-study section enters the viewport (IntersectionObserver, threshold ~0.4), once per page view | `case_id`, `service?` | `case_id` is a public project slug (non-PII). |
+
+No other events and no other parameters are emitted. `page_type` is one of:
+`home`, `services`, `service`, `projects`, `project`, `studio`, `contact`,
+`other`.
+
+### Where each event fires
+
+- **`cta_click`**
+  - Service landing page CTA → `/kontakt` — `components/oferta/ServiceLandingPage.tsx`, `position: "service-cta"`, `service: <service slug>`.
+  - Project case → brief CTA → `/kontakt#brief` — `components/ProjectServiceCta.tsx`, `position: "project-cta"`, `service: <related service slug>` (omitted when the cross-link target is the `/oferta` hub).
+  - Services hub links block — `components/oferta/ServicesHubLinks.tsx`, `position: "hub"`, `service: <service slug>`.
+- **`email_click`** — `components/AddressBlock.tsx` footer email link, `position: "footer"`. (No homepage/footer `/kontakt` CTA exists to instrument.)
+- **`brief_start` / `brief_submit` / `brief_mailto_fallback`** — `components/kontakt/BriefForm.tsx`, keyed off the `useActionState` transitions (`brief-state.ts`).
+- **`case_engaged`** — `components/CaseStudySection.tsx` (observes its own `<section>` root).
+
+### Delivery mechanism
+
+A single client `AnalyticsListener` (`components/AnalyticsListener.tsx`) is
+mounted once in the layout **only when GA4 is configured**. It reads the
+`data-analytics*` attributes via document-level click delegation, so server
+components stay server components and only gain inert data attributes. Case and
+brief events live inside components that are already client components.
+
+---
+
+## Environment variables
+
+| Var | Effect | Default |
+|-----|--------|---------|
+| `NEXT_PUBLIC_GA4_ID` | GA4 measurement id (`G-XXXXXXXXXX`). When set, `components/GoogleAnalytics.tsx` injects gtag.js via `next/script` (`afterInteractive`). When unset, nothing loads. | unset |
+
+Documented in `.env.example`. Validated against `/^G-[A-Z0-9]+$/i` before it is
+interpolated into the inline consent script.
+
+---
+
+## Consent posture
+
+- **Consent Mode v2, denied by default.** Before any `config` runs, the loader
+  sets `ad_storage`, `ad_user_data`, `ad_personalization`, and
+  `analytics_storage` all to `'denied'`.
+- **Cookieless pings only** until consent is granted: GA4 sends anonymous,
+  cookieless pings and stores nothing on the device.
+- **CMP pending — decision-log G4.** No CMP has been chosen (G4-5 OPEN) and the
+  consent/PII basis is unconfirmed (G4-4 OPEN). Until then, consent must stay
+  denied by default.
+- **Grant hook, no banner.** `grantAnalyticsConsent()` in `lib/analytics.ts`
+  calls `gtag('consent', 'update', { analytics_storage: 'granted' })` for a
+  future CMP to call once a visitor opts in. `denyAnalyticsConsent()` is the
+  inverse. Ad signals stay denied — this site measures analytics only. **No
+  cookie banner is built here** (that is the CMP's job, blocked on G4).
+
+---
+
+## QA steps (once a GA4 property exists)
+
+1. Set `NEXT_PUBLIC_GA4_ID` in `.env.local`, run `pnpm build && pnpm start`.
+2. Confirm the built HTML now contains the gtag snippet and the consent-default
+   block runs **before** `config` (view source / network).
+3. **GA4 DebugView** (`gtag('config', …, { debug_mode: true })` or the GA
+   Debugger extension): trigger each event and confirm the exact param set:
+   - `cta_click` from a service CTA, a project CTA, and a hub link.
+   - `brief_start` on first focus of the brief form; `brief_submit` on a
+     confirmed Resend success; `brief_mailto_fallback` on the mailto path.
+   - `email_click` from the footer email link (verify **no** address param).
+   - `case_engaged` by scrolling a project case block into view (fires once).
+4. **Tag Assistant** (tagassistant.google.com): confirm Consent Mode shows
+   `analytics_storage: denied` on load, and that a `consent update` flips it to
+   `granted` after `grantAnalyticsConsent()` runs.
+5. Confirm de-duplication: `brief_submit` carries a unique `event_id` per
+   submission (server-side Measurement Protocol join is B02 work).
+6. Re-verify the inert state: unset the env var, rebuild, confirm no
+   gtag/googletagmanager reference in the HTML.
+
+---
+
+## Remaining for the business (backlog B02, gate G4)
+
+Engineering has shipped the inert scaffold. The following are **not** something
+engineering can finish alone — they need account access and a privacy decision:
+
+- **Create the GA4 property** and obtain the measurement id → set
+  `NEXT_PUBLIC_GA4_ID`.
+- **Choose a CMP** and wire it to `grantAnalyticsConsent()` /
+  `denyAnalyticsConsent()` (decision-log **G4-5**); confirm the consent/PII
+  basis and retention (**G4-4**).
+- **Confirm the qualified-lead definition + CRM stages** (**G4-1**) so
+  `brief_submit` can be joined to outcomes.
+- **Verify GSC (Google Search Console) + Bing Webmaster** and connect the CRM
+  (backlog **B02**); wire the server-side Measurement Protocol join for
+  `brief_submit` de-duplication.
+
+See `docs/playbook/backlog.md` (**B02**) and `docs/playbook/decision-log.md`
+(**G4**).

--- a/docs/playbook/backlog.md
+++ b/docs/playbook/backlog.md
@@ -1,0 +1,121 @@
+# Implementation Backlog — Status Board
+
+**Purpose:** map the playbook's P0 backlog (**B01–B12**, §17.1) and P1/P2 items (§17.2) onto three buckets so it is always clear what can proceed now, what needs a person outside engineering, and what is hard-blocked by an unresolved decision:
+
+- **(A) Implemented in this repo branch** — technical work being built on branch `claude/opus-report-delegation-hia53j`. These ship as *structure/scaffold*; they must not publish an unconfirmed business fact (see `decision-log.md`).
+- **(B) Needs business action / account access** — requires an account, a login, a human decision, or an external relationship engineering cannot create.
+- **(C) Blocked by gate** — cannot proceed at all until a `decision-log.md` gate (G0–G6) is resolved.
+
+Most items appear in more than one bucket: the *scaffold* is in (A), while the *facts/content/accounts* that fill it sit in (B) or (C). The bucket tag on each item marks where its **critical path** currently sits.
+
+**Acceptance criteria below are condensed from §17.1/§17.2. The authoritative versions are in the playbook.**
+
+---
+
+## Master map
+
+| ID | Item | Critical-path bucket | Blocking gate(s) |
+|---|---|---|---|
+| B01 | Define ideal projects & qualified leads | C | G0, G4 |
+| B02 | Connect GA4, GSC, Bing, CRM + event map | B | G4 |
+| B03 | Audit indexing, IA, PL/EN, images | A | — (needs GSC access for full verification → B) |
+| B04 | Services hub + four P0 landing pages | A (scaffold) / C (copy) | G0, G2 |
+| B05 | Project-brief form + confirmations | A (scaffold) / C (bands, SLA) | G4 |
+| B06 | Eight evidence-standard case studies | A (structure) / C (rights, facts) | G3 |
+| B07 | Complete & reconcile Google Business Profile | B | G1, G6 |
+| B08 | Review request/reply program | B | G4, G6 |
+| B09 | Entity graph (business, people, services, pages) | A | G1, G2 (facts) |
+| B10 | Configure robots/WAF for legit crawlers | A (code) / C (policy) | G6 |
+| B11 | Three pillars: process, cost, studio choice | A (structure) / C (facts) | G2 |
+| B12 | Dehesa press kit + tailored pitch | A (draft done) / C (rights) | G3, G6 |
+| P1 | Interior-modernisation landing page | C | G0, G2 |
+| P1 | Design-supervision landing page | C | G2 |
+| P1 | Purchaser-changes cluster | C | G2 |
+| P1 | Wrocław/tenement pillar | C | G2, G5 |
+| P1 | Bing Webmaster + IndexNow | B | G6 |
+| P1 | Quarterly AI audit | A (kit done) / B (runs) | — |
+| P1 | Two additional press kits | C | G3 |
+| P1 | Post-occupancy case study (12–24 mo) | C | G3 |
+| P2 | Original report / detail atlas | C | G3, G5 |
+| P2 | Budget calculator | C | G2 |
+| P2 | Neuroinclusive content | C | G5 |
+| P2 | Expand English content | B | G0 |
+
+---
+
+## Bucket A — Implemented in this repo branch (`claude/opus-report-delegation-hia53j`)
+
+These deliverables are built now as engineering artefacts. They are **index-eligible structure with placeholder/confirmed-only facts** — every business fact stays gated until `decision-log.md` clears it. The branch keeps existing crawlability invariants (nav links in server HTML; server-rendered projects grid).
+
+| ID | What is being built on this branch | Condensed acceptance criteria (§17.1) | Fact dependency |
+|---|---|---|---|
+| **B03** | **Technical-SEO audit + fixes.** Indexing/canonical audit, sitemap correctness, crawlable HTML links, PL/EN pairing (`hreflang`, `x-default`), semantic image alts/dimensions. Repo already ships `app/sitemap.ts`, `app/robots.ts`, per-page canonicals via `pageMetadata`. | Prioritised issue register closed or accepted; priority URLs index-eligible with correct canonical/language/image signals; no non-indexable priority URL, canonical conflict, redirect loop, or broken PL/EN pair. | Full verification needs **GSC/Bing access (B)**; on-page fixes proceed now. |
+| **B04** | **Services hub + four P0 landing-page shells.** Route + reusable service-page template (`components/oferta/…` pattern) for: apartment design, house design, commercial interiors, + one more per G0. Crawlable, internally linked, with CTA slot to the brief form. **Copy is placeholder** until service truth is approved. | Crawlable, index-eligible, measured, reviewed URLs; each page has an approved *real* offer + proof before it publishes real copy (§B04 stop condition). | Real service copy **blocked by G0 (which four) + G2 (scope truth)** → Bucket C. |
+| **B05** | **Project-brief form + confirmation scaffold.** Accessible form (visible labels, keyboard order, error recovery, file-size limits shown), server-side success as the `brief_submit` source with non-identifying `event_id`, confirmation screen, alternative email path. Fields per §7.1. | Accessible, tested; valid submissions reach CRM once; confirmation works; no PII to GA4; duplicate events prevented. | Budget **bands, response SLA, retention, CMP, file limits blocked by G4** → Bucket C; CRM endpoint needs **B02 (B)**. |
+| **B06** | **Case-study structure/template.** Templates A/B/C (§15) wired to `data/projects.ts` (`Project` type already carries scope, area, year, credits, description blocks, before/after sliders). Problem→decision→result skeleton + service-link + CTA slots. | Each case has scope, problem, decisions, evidence, service link, CTA; no outcome inferred from images. | Per-project **rights + verified facts blocked by G3** → Bucket C. Structure ships now. |
+| **B09** | **Entity graph.** Extend the existing JSON-LD (currently `ProfessionalService` in `layout.tsx`, `CreativeWork` + `BreadcrumbList` per project) into a stable `@id` graph for org, people, services, pages (§10.2). Migrate the deprecated `ProfessionalService` → `Organization`/`LocalBusiness`. | Validator passes; visible facts match JSON-LD; one stable `@id` per entity; no duplicate nodes; URL Inspection recorded. | `LocalBusiness` vs `Organization`, legal name, founders, phone/hours **blocked by G1/G1-3**; service nodes need **G2**. |
+| **B10** | **robots/WAF config for legitimate crawlers.** Keep search/AI crawler access working; separate *search* access from *training-crawler* policy in code so the decision is switchable. Current `robots.ts` is allow-all. | Logs confirm approved access; training-crawler decisions kept separate; no security/performance harm. | The **policy itself is a G6 decision** (do not change unilaterally) → Bucket C. |
+| **B11** | **Pillar page structure** for process / cost / studio-choice (§13). Routes, headings, internal-link scaffolding, author + review-date slots, measured CTA. | Quality ≥16/20; original proof; measured CTA; named maintenance owner. | Real process/cost facts **blocked by G2**; cost claims need a **G5 reviewer** → Bucket C. |
+| **B12** | **Dehesa press kit (draft).** ✅ Delivered as `press-kit-dehesa.pl.md` + `.en.md` (this folder): 760-word PL/EN descriptions, 120-word summary, data sheet, image inventory, bio, links, 10-outlet `[PROPOSED]` list. | Complete kit + 10 individually selected, recorded pitches. | Send **blocked by G3 (rights) + G6 (outreach approval)** → Bucket C. |
+| **P1 · AI audit** | **Quarterly AI-audit kit.** ✅ Delivered as `ai-audit-prompts.md`: 30 PL + 10 EN fixed prompts, protocol, coding scheme, scoring template, targets. | Reproducible report; consistent method; output order never treated as rank. | Actually **running** it each quarter = Bucket B (Marketing). |
+| **Ops docs** | **This documentation set.** `decision-log.md`, `nap-source-of-truth.md`, `ai-audit-prompts.md`, `press-kit-dehesa.*.md`, `backlog.md`. | Every gate/fact has an owner, deliverable, dependency, acceptance evidence, review date, stop condition (§17.3). | — |
+
+> **Analytics scaffold note:** the site already loads Vercel Web Analytics + Speed Insights (`layout.tsx`). The *event map* and GA4/GSC/Bing/CRM wiring (B02) is **not** something engineering can finish alone — it needs property access and a consent/CMP decision (Bucket B + gate G4).
+
+---
+
+## Bucket B — Needs business action / account access
+
+Engineering cannot create these; they need a login, an account claim, a human relationship, or an owner decision.
+
+| ID | Item | Who acts | Condensed acceptance criteria | Gate ref |
+|---|---|---|---|---|
+| **B02** | Connect **GA4, GSC, Bing Webmaster, CRM** + wire the event map | Analytics/CRM owner | End-to-end tested; dashboard receives deduplicated data; every contact route has source/landing/status/outcome. | G4 (`decision-log` G4-1/4/5) |
+| **B07** | Claim & complete **Google Business Profile**; reconcile NAP | Local owner | Approved settings sheet, rights-cleared media (20–30 launch images), tagged landing link with UTM; NAP matches `nap-source-of-truth.md`. | G1 (name/address/phone/hours), G6-1 (ownership + category) |
+| **B08** | **Review request/reply program** | Studio/sales | Neutral workflow, three milestone templates, response SLA ≤5 business days, owner; **no incentives**, no gating. | G4 (CRM milestones), G6-4 (authorise) |
+| **P1 · Bing** | **Bing Webmaster + IndexNow** | Dev + account owner | Verification + URL tests; submit sitemap; pause while URL errors remain. | G6-2 (Bing Places ownership) |
+| **P1 · AI audit runs** | Execute the quarterly audit using the kit | Marketing | Run on ChatGPT/Gemini/Perplexity in clean sessions; record evidence; code answers. | — (kit ready) |
+| **P2 · English** | Expand English content | Marketing | Only key useful URLs; stop without international pipeline/PR. | Prioritise per G0 |
+
+---
+
+## Bucket C — Blocked by gate (cannot proceed until decision recorded)
+
+Each row is hard-blocked. Resolve the gate in `decision-log.md`, then the paired Bucket-A scaffold can be filled and shipped.
+
+| ID | Item | Condensed acceptance criteria | Blocking gate → decision-log ref |
+|---|---|---|---|
+| **B01** | Define ideal projects & qualified-lead criteria | Approved fit criteria, exclusions, reason codes. **Foundational — unblocks B04/B05 targeting and all measurement.** | **G0** (G0-1..4) + **G4** (G4-1) |
+| **B04** | Real Services-hub + landing-page copy | Approved real offer + proof per page before publish. | **G0** (which 3–4), **G2** (scope truth) |
+| **B05** | Brief-form business logic (budget bands, SLA, retention, consent) | Bands/SLA/retention/CMP/file-limits confirmed; consent matches privacy notice. | **G4** (G4-2..6) |
+| **B06** | Case-study *content* (per project) | Verified problem/decision/result + rights + no private data. | **G3** (G3-1; Dehesa G3-2) |
+| **B10** | Training-crawler / WAF *policy* | Approved crawler-access policy; search vs training separated. | **G6-3** (confirm, don't change unilaterally) |
+| **B11** | Pillar *content* (process, cost, studio-choice) | Original first-hand proof; cost claims reviewed. | **G2** (all), **G5** (cost/specialist) |
+| **P1** | Interior-modernisation landing page | Demonstrated demand + two proofs + approved offer; revise/stop after two quarters without qualified assistance. | **G0**, **G2** |
+| **P1** | Design-supervision landing page | Reviewed role + scope + FAQ + proof; stop if no real offer/capacity. | **G2** (G2-4; FAQ F26/F27) |
+| **P1** | Purchaser-changes cluster | Pillar + three supporting items; merge on cannibalisation. | **G2** (FAQ F33) |
+| **P1** | Wrocław/tenement pillar | Pillar + case with ≥2 real regional facts; stop without genuine local value. | **G2**, **G5-2** (conservation) |
+| **P1** | Two additional press kits | Two complete kits + tailored pitch with true PL/EN material; stop without rights. | **G3** |
+| **P1** | Post-occupancy case study (12–24 mo) | Published post-occupancy evidence; stop without evaluation. | **G3** (consent) |
+| **P2** | Original report / detail atlas | Unique data + defensible method + privacy + reviewer; stop if generic/unsafe. | **G3**, **G5** |
+| **P2** | Budget calculator | Approved model + volatile-data owner + update capacity; stop if it can't stay current. | **G2** (pricing model) |
+| **P2** | Neuroinclusive content | Competent expert + client consent + careful terminology + demand; stop without competence/consent. | **G5-1** (never a medical claim) |
+
+---
+
+## Sequencing reminder (§17.1 dependency order)
+
+1. **B01** unlocks qualification, page targeting, form bands, measurement — do this first.
+2. **B02** starts before publication so the baseline is trustworthy.
+3. **B03** defines migration/template work before new architecture ships.
+4. **B04 + B05** share service-truth, UI, accessibility, analytics dependencies.
+5. **B06** supplies proof for B04/PR; publish landing pages in stages if proof isn't ready.
+6. **B07/B08** can start early once G1/G4/G6 clear.
+7. **B09** follows confirmed entities + stable templates.
+8. **B10** follows security review + official crawler docs + the G6-3 policy decision.
+9. **B11** follows IA + proof workflow.
+10. **B12** follows rights clearance — never pitch a non-exclusive asset as exclusive.
+
+**Governance (§17.3):** every item needs one accountable human, a deliverable, a dependency list, acceptance evidence, a metric, a review date, and a stop condition. P1/P2 must not bypass unresolved P0 data-quality, service-truth, rights, or crawlability failures.
+
+**Related:** `decision-log.md` (gates), `nap-source-of-truth.md` (G1 facts), `ai-audit-prompts.md`, `press-kit-dehesa.*.md`.

--- a/docs/playbook/decision-log.md
+++ b/docs/playbook/decision-log.md
@@ -1,0 +1,92 @@
+# Decision Log — Confirmation Gates & Open Business Facts
+
+**Purpose:** master register of every business decision the SEO / AI-visibility / lead-gen playbook marks `[REQUIRES CONFIRMATION]` or gates behind **G0–G6**. No implementation work that depends on one of these facts may ship until the row is resolved. This is the single place to record who decides and when.
+
+**Scope rule (hard):** engineering may build *structure* (empty service pages, form scaffold, schema shells, ops docs) ahead of a decision, but must **never publish a business fact** — price, hour, phone number, SLA, capacity claim, review quote, scope promise — until the corresponding row below moves to `RESOLVED` with a written owner decision. See playbook §2.3 (evidence hierarchy) and §2.4 (gates).
+
+**How to use:** work the `OPEN` rows top-down. When a decision is made, change `Status` to `RESOLVED`, fill `Date`, and record the exact wording of the decision in the CRM / decision doc referenced by the approver. Do not delete rows — supersede them.
+
+**Legend — Status:** `OPEN` (undecided, blocking) · `RESOLVED` (owner decision recorded) · `DEFERRED` (consciously parked with a review date).
+
+---
+
+## Part A — Confirmation gates G0–G6
+
+| ID | Gate | Decision needed | Why it blocks / what it unlocks | Suggested approver | Status | Date |
+|---|---|---|---|---|---|---|
+| G0-1 | G0 business fit | Confirm the **3–4 preferred project types** the studio actively wants (e.g. apartments, houses, commercial/hospitality, brand+space) | Blocks B01 (ideal-project + qualified-lead definition), page targeting for the Services hub (B04), brief-form routing (B05), and all positioning copy. Unlocks the whole P0 sequence. | Founders / business owner | OPEN | — |
+| G0-2 | G0 business fit | Confirm **exclusions** — project types, sectors, or job sizes the studio will *not* take | Prevents landing pages and AI answers from advertising work the studio won't do; feeds "non-fit reason codes" in B01. | Founders / business owner | OPEN | — |
+| G0-3 | G0 business fit | Confirm **minimum viable scope** (smallest engagement accepted — e.g. layout-only? single room? full documentation only?) | Directly answers FAQ F02/F04; sets the floor for brief-form qualification and for what the Services pages may promise. | Founders / business owner | OPEN | — |
+| G0-4 | G0 business fit | Confirm **current capacity** and commercial priorities (how many concurrent projects, which are priority) | Governs whether landing-page experiments and PR may proceed (a page with no capacity behind it must not ship — §2.6 stop condition). | Founders / business owner | OPEN | — |
+| G0-5 | G0 business fit | Approve the **positioning statement** (§3.4 proposed line is pending G0) | Blocks homepage / Services / Studio copy and the AI-audit "brand facts" baseline. | Founders / business owner | OPEN | — |
+| G1-1 | G1 public facts | Confirm **opening hours** (or "by appointment only" policy) | Not published anywhere in the repo. Required for GBP (B07), Bing Places, and any `LocalBusiness`/hours schema. Blocks the local entity workstream. | Business owner | OPEN | — |
+| G1-2 | G1 public facts | Confirm a **public phone number** (or a documented "email-only" decision) | No phone appears on the site, in JSON-LD, or in llms.txt. Blocks NAP completeness (B07), GBP, and the "alternative contact path" the brief form requires (§7.3). | Business owner | OPEN | — |
+| G1-3 | G1 public facts | Confirm the **address & reception policy**: is Zaporoska 83/15, 53-415 Wrocław a client-receiving office, or service-area only? | The address is *already published* (JSON-LD in `app/[locale]/layout.tsx`, footer strings, llms.txt line 43). GBP rules (§9.1) require hiding the address if clients are not received there. Decides `LocalBusiness` vs `Organization` schema (§10.1). | Business owner | OPEN | — |
+| G1-4 | G1 public facts | Confirm the **legal/registered name** and company registration (NIP/REGON/KRS) for the entity graph and any invoicing/legal blocks | Site publishes only the trade name "Kool Studio". Needed before `Organization` legal-name schema and any B2B/contract page. | Business owner | OPEN | — |
+| G1-5 | G1 public facts | Confirm **founder legal names & bios** — site/JSON-LD say "Ola Kilińska" and "Ola Leszczyńska"; playbook §3.1 cites "Aleksandra Kilińska / Aleksandra Leszczyńska" (LinkedIn) | Name mismatch (Ola ↔ Aleksandra) must be reconciled before `Person` schema and bio pages, or the entity graph will assert conflicting facts. | Business owner | OPEN | — |
+| G1-6 | G1 public facts | Confirm **official profile URLs** to list as `sameAs` — LinkedIn (`pl.linkedin.com/company/koolstudio` per §3.1 but **not** in repo), GBP, Bing Places, any others | Only Instagram is currently referenced (`lib/site.ts`). `sameAs` completeness helps entity disambiguation (§10, §11). | Business owner | OPEN | — |
+| G2-1 | G2 service truth | Confirm the **exact design phases** and what each delivers | Blocks the process pillar (B11), Services pages (B04), and FAQ F09/F10. Answers must come from approved service truth, never competitor practice (§14.7). | Studio lead + legal/commercial reviewer | OPEN | — |
+| G2-2 | G2 service truth | Confirm the **construction-documentation package contents** (drawing list, schedule, specification) | FAQ F14; Services page scope; case-study "documentation" claims. | Studio lead | OPEN | — |
+| G2-3 | G2 service truth | Confirm the **revision / layout-option policy** (how many options, how many revision rounds, what counts as a scope change) | FAQ F11, F12; brief-form expectation-setting; contract page. | Studio lead + legal reviewer | OPEN | — |
+| G2-4 | G2 service truth | Confirm **design-supervision (nadzór autorski) scope** — visits, reports, exclusions, and its legal separation from a construction manager | FAQ F26, F27; unlocks the P1 "design supervision" landing page (§17.2); appears in most project scopes already. | Studio lead + legal reviewer | OPEN | — |
+| G2-5 | G2 service truth | Confirm the **procurement / purchasing role** — who orders, who handles complaints, and the supplier-commission/discount transparency policy | FAQ F22, F23, F24; required before any "we manage purchasing" claim. | Studio lead + legal/commercial reviewer | OPEN | — |
+| G2-6 | G2 service truth | Confirm the **pricing-disclosure policy** — what (if anything) about fees may be published | FAQ F17, F44; §14.7 forbids inventing a universal rate. Blocks all cost content (B11 cost pillar). | Founders + studio lead | OPEN | — |
+| G3-1 | G3 evidence rights | Confirm, **per project**, separate consent scopes for: portfolio use, plans/drawings, photography, client quotes, budgets, PR, social, and paid media | Blocks case studies (B06), press kits (B12), and any image schema (`ImageObject` rights metadata, §10). Rights are per-scope, not blanket. | Studio lead / data owner | OPEN | — |
+| G3-2 | G3 evidence rights | Confirm **Dehesa** photography licence & release from Katarzyna Ramocka and Michał Woroniak (ZASOBY STUDIO) for press redistribution and high-res supply | Gates the Dehesa press kit send (B12) — see `press-kit-dehesa.*.md`. Credited but licence scope unknown. | Studio lead / PR | OPEN | — |
+| G3-3 | G3 evidence rights | Confirm **collaborator credit approvals** (blsk.studio, Jord Studio, arch_it, BUCK.STUDIO, Michał Sokołowski) for any published case/press use | §12.2 acceptance criteria: collaborator credits must be approved before publication. | Studio lead / PR | OPEN | — |
+| G4-1 | G4 analytics | Confirm the **qualified-lead definition** and CRM stages | Blocks B01, B02, the brief form (B05), and every conversion KPI. Nothing downstream can be measured without it. | Business owner + analytics/privacy owner | OPEN | — |
+| G4-2 | G4 analytics | Confirm the **implementation-budget bands** to show in the brief form (§7.1 leaves them `[REQUIRES CONFIRMATION]`) | Blocks the budget field in B05 and FAQ cost framing. Must exclude the design fee if that is the approved model. | Business owner | OPEN | — |
+| G4-3 | G4 analytics | Confirm the **response SLA** stated after brief submission (§7.2) | Published on the confirmation screen and used in review-workflow copy. Must not be invented. | Business owner + sales owner | OPEN | — |
+| G4-4 | G4 analytics | Confirm **data retention, privacy/consent basis, and PII controls** for enquiry data | §7.3: no PII may reach GA4; consent must match the privacy notice. Blocks form go-live. | Analytics/privacy owner | OPEN | — |
+| G4-5 | G4 analytics | Confirm the **consent-management / CMP tooling** for analytics (the site currently loads Vercel Analytics + Speed Insights with no visible CMP) | Consent basis and cookie policy must be settled before scaling any tracking (§7.3, §16.1). | Analytics/privacy owner | OPEN | — |
+| G4-6 | G4 analytics | Confirm **accepted file types & size limits** for brief attachments (§7.1) | Needed before the upload control ships in B05. | Web/analytics + privacy owner | OPEN | — |
+| G5-1 | G5 specialist claims | Name the **accessibility / neuroinclusion reviewer** required before any sensory-aware or ADHD-adjacent content is published | The Strachowicka and Gdańsk-library angles (§12.1) and FAQ F37 cannot be published as anything beyond design-intent without a named competent expert (§2.4, §3.3). Careful wording only — never a medical claim. | Relevant qualified expert | OPEN | — |
+| G5-2 | G5 specialist claims | Name **conservation / historic-tenement reviewer** for Wrocław tenement and conservation-approval content | FAQ F41, F42; the P1 Wrocław/tenement pillar. | Relevant qualified expert | OPEN | — |
+| G5-3 | G5 specialist claims | Name reviewers for any **structural, fire, sanitary (Sanepid), legal, or cost** assertions before they are published | llms.txt already claims "Sanepid support" — that claim needs a competent owner. Any cost model needs a reviewer (§2.4). | Relevant qualified experts | OPEN | — |
+| G6-1 | G6 external change | Confirm **GBP ownership / claim status** and authorise profile edits (the repo only has a `maps.app.goo.gl` link — ownership unknown) | Blocks B07 (GBP completion) and the whole 90-day local plan (§9.2). No external edit without this. | Account/channel owner | OPEN | — |
+| G6-2 | G6 external change | Confirm **Bing Places** ownership and authorise verification | Blocks the P1 "Bing Webmaster + Bing Places" work (§11.2, §17.2). | Account/channel owner | OPEN | — |
+| G6-3 | G6 external change | **Decide the training-crawler policy.** The site's `robots.ts` currently returns allow-all (`User-agent: *, Allow: /`), so `GPTBot`, `Google-Extended`, `CCBot` etc. are **already permitted**. Confirm whether to keep, restrict, or split search vs training crawler access. | This is a *decision to confirm, not to change unilaterally* (§2.2 authority boundary; §11.2 keeps `Google-Extended` and `GPTBot` as separate policy choices). B10 must not alter crawler access without this sign-off. | Account/channel owner + security | OPEN | — |
+| G6-4 | G6 external change | Authorise **press outreach** and the review-request program before either goes live | §9.1 / §12: outreach and review requests are external actions requiring owner approval; review requests must never offer incentives. | Account/channel owner | OPEN | — |
+
+---
+
+## Part B — FAQ answers requiring confirmation (§14)
+
+Each of these FAQ answers is marked `[REQUIRES CONFIRMATION]` in the playbook and cannot be written until the underlying service truth is approved. Gate shown is the primary blocker (most sit behind **G2 service truth**; a few also need **G1** service-area or **G5** specialist review). Question text is quoted verbatim.
+
+| ID | Gate | Question (decision needed) | Why it blocks / what it unlocks | Suggested approver | Status | Date |
+|---|---|---|---|---|---|---|
+| F04 | G2 / G0 | "Do you design individual rooms?" — confirm minimum scope and when a single-room job makes sense | Depends on G0-3 minimum scope. Unlocks a truthful FAQ + brief-form floor. | Studio lead | OPEN | — |
+| F05 | G1 / G0 | "Do you work remotely outside Wrocław?" — confirm remote surveys, visits, supervision, and service area | Sets the published service-area policy (also feeds NAP & GBP areaServed). | Business owner | OPEN | — |
+| F09 | G2 | "How long does an interior-design project take?" — confirm realistic ranges by area/scope/disciplines | Process pillar + FAQ; no universal promise allowed. | Studio lead | OPEN | — |
+| F11 | G2 | "How many layout options will I receive?" — confirm option & iteration policy | See G2-3. | Studio lead | OPEN | — |
+| F12 | G2 | "How many revision rounds are included?" — confirm limit, consolidated feedback, scope-change rule | See G2-3; also feeds the contract page. | Studio lead + legal | OPEN | — |
+| F14 | G2 | "What does the construction-documentation package include?" — confirm the actual drawing/schedule/specification list | See G2-2. | Studio lead | OPEN | — |
+| F15 | G2 | "Who coordinates specialist building systems?" — confirm boundaries between interior designer and specialist designers | Defines liability boundary in Services + supervision pages. | Studio lead + legal | OPEN | — |
+| F16 | G2 | "How are decisions made when household members disagree?" — confirm the priorities-workshop / decision-criteria method | Process pillar; must reflect real method. | Studio lead | OPEN | — |
+| F17 | G2 | "How much does an interior-design service cost?" — confirm pricing factors and scope | See G2-6; never invent one universal rate. | Founders + studio lead | OPEN | — |
+| F21 | G2 | "Does the designer help control the budget?" — confirm estimates, alternatives, control points | Cost pillar; budget-control claim needs a real process behind it. | Studio lead | OPEN | — |
+| F22 | G2 | "Will I receive a shopping list with prices?" — confirm specification scope, price validity, substitutes | See G2-5. | Studio lead | OPEN | — |
+| F23 | G2 | "Does the studio receive supplier commissions?" — confirm the transparent discount/commission/remuneration policy | Trust-critical; see G2-5. | Founders + legal | OPEN | — |
+| F24 | G2 | "Who places orders and handles complaints?" — confirm purchasing models and responsibility | See G2-5. | Studio lead + legal | OPEN | — |
+| F25 | G2 | "Do you recommend renovation contractors you trust?" — confirm recommendation criteria, independence, separate contractor agreement | Liability & independence must be settled before publishing. | Studio lead + legal | OPEN | — |
+| F26 | G2 | "Does the design include design supervision?" — confirm visits, reports, exclusions, and pricing | See G2-4; unlocks the supervision landing page. | Studio lead | OPEN | — |
+| F30 | G2 | "Who inspects completed work?" — confirm partial inspections and party roles | Delivery-phase truth; role separation. | Studio lead + legal | OPEN | — |
+| F32 | G2 | "Is support available after the project is complete?" — confirm as-built info, review visits, complaints handling | Enables the post-occupancy proof/case (P1, §17.2). | Studio lead | OPEN | — |
+| F33 | G2 | "Do you help with developer-managed, buyer-requested pre-handover changes?" — confirm layout/systems/deadline analysis | Feeds the P1 purchaser-changes cluster (§17.2). | Studio lead | OPEN | — |
+| F36 | G2 | "Do you design custom furniture?" — confirm drawing scope, maker relationship, prototypes, inspection | Scope is broadly true (most projects list furniture design) but the *depth* claims need confirming. | Studio lead | OPEN | — |
+| F39 | G2 | "Do you help select art and collectible objects?" — confirm curation, display, lighting, safety, partner roles | New service territory; only publish if real. | Studio lead | OPEN | — |
+| F40 | G2 | "Does the design include a terrace or entrance area?" — confirm the boundary between interior, architecture, and landscape | Scope-boundary clarity; avoids over-promising. | Studio lead | OPEN | — |
+| F41 | G2 / G5 | "Do you undertake projects in historic Wrocław tenements?" — confirm diagnostics, formalities, conservation roles | Needs G5-2 conservation reviewer; unlocks the Wrocław/tenement pillar. | Studio lead + conservation expert | OPEN | — |
+| F42 | G5 | "Do you assist with conservation approvals?" — confirm power of attorney, responsibility, specialist collaboration | Legal/conservation liability; needs a named expert. | Conservation/legal expert | OPEN | — |
+| F44 | G2 | "How is a commercial-interior design fee calculated?" — confirm area/sector/timing/fit-out/approvals factors | See G2-6; commercial pricing framing. | Founders + studio lead | OPEN | — |
+| F45 | G2 / G0 | "Do you design rental apartments and entire portfolios?" — confirm standard, target group, TCO, scaling | Depends on G0 fit; enables the investor cluster (K12). | Founders + studio lead | OPEN | — |
+| F48 | G2 / G5 | "Do you work in commercial premises that remain operational?" — confirm phasing, health & safety, working hours, downtime | Needs H&S input; operational-fit-out claim. | Studio lead + specialist | OPEN | — |
+
+---
+
+**Related documents**
+
+- `nap-source-of-truth.md` — resolves G1 facts already published vs. still missing.
+- `backlog.md` — maps every gate above to the P0/P1/P2 item it blocks.
+- Playbook §2.4 (gate table), §3 (truth set), §14 (full FAQ plan).

--- a/docs/playbook/nap-source-of-truth.md
+++ b/docs/playbook/nap-source-of-truth.md
@@ -1,0 +1,109 @@
+# NAP & Entity Source of Truth
+
+**Purpose:** the single approved record of kool studio's Name / Address / Phone and core entity facts. Every surface — website, JSON-LD, `/llms.txt`, GBP, Bing Places, directories, press kits — must match this sheet. When any fact changes, change it **here first**, then propagate to every row in the "where this fact appears" column.
+
+**Provenance rule:** every value below is populated **only** from what the repository already publishes. Facts the repo does *not* contain are marked `[REQUIRES CONFIRMATION]` and must be resolved via `decision-log.md` (gate G1) before they go on any external profile. Do not copy the LinkedIn-sourced facts from the playbook (e.g. team size, "Aleksandra" name form) onto live surfaces until confirmed — they are not in the repo.
+
+**Owner:** Local owner + Business owner (per playbook §4.2, §9). Last reconciled against repo: 2026-07-22.
+
+---
+
+## 1. Name
+
+| Field | Value (from repo) | Where this fact appears |
+|---|---|---|
+| Trade name (canonical, schema) | **Kool Studio** | JSON-LD `name` (`app/[locale]/layout.tsx`); `metadata.title.default` |
+| Display styling (lowercase brand) | **kool studio** | `metadata.title.template` (`%s \| kool studio`); llms.txt heading; site chrome |
+| Social handle styling | **kool.studio** | Instagram handle (`lib/site.ts`); llms.txt |
+| Legal / registered company name | `[REQUIRES CONFIRMATION]` — not published in repo | (target: `Organization.legalName`) |
+| Company registration (NIP / REGON / KRS) | `[REQUIRES CONFIRMATION]` — not in repo | (target: invoicing/legal footer, entity graph) |
+
+> **Rule (§9.1):** use the exact real-world name. Never append keywords or cities ("Kool Studio Wrocław interior design") on GBP or profiles.
+
+## 2. Address
+
+| Field | Value (from repo) | Where this fact appears |
+|---|---|---|
+| Street address | **Zaporoska 83/15** | JSON-LD `address.streetAddress` (`layout.tsx`); footer string `"STUDIO: ZAPOROSKA 83/15, WROCŁAW"` (`messages/pl.json` + `en.json`, key `footer.address`); llms.txt line 43 |
+| Postal code | **53-415** | JSON-LD `address.postalCode`; llms.txt line 43 |
+| City (locality) | **Wrocław** | JSON-LD `address.addressLocality`; footer string; llms.txt |
+| Region | **Dolnośląskie** (Lower Silesia) | JSON-LD `address.addressRegion` |
+| Country | **PL** (Poland) | JSON-LD `address.addressCountry`; llms.txt |
+| Geo coordinates | **lat 51.09168, lng 17.01557** | JSON-LD `geo` (`layout.tsx`) |
+| Map link | **https://maps.app.goo.gl/f3nJEyLJXxKStLvPA** | JSON-LD `hasMap`; `AddressBlock.tsx` (`<a href>`), used on homepage footer + kontakt page |
+| Reception / service-area policy | `[REQUIRES CONFIRMATION]` — is this a client-receiving office or service-area-only? (governs whether the address is shown or hidden on GBP, and `LocalBusiness` vs `Organization` schema) | See `decision-log.md` G1-3 |
+
+> **Consistency note:** the address is displayed as `STUDIO: ZAPOROSKA 83/15, WROCŁAW` (no postal code) in the footer/kontakt UI, but the full postal address (`53-415`, region, country) exists only in JSON-LD and llms.txt. Keep both representations pointing at the same real address.
+
+## 3. Phone & contact
+
+| Field | Value (from repo) | Where this fact appears |
+|---|---|---|
+| Email | **hello@koolstudio.pl** | JSON-LD `email` (`layout.tsx`); `AddressBlock.tsx` (`mailto:`); footer string `footer.email`; llms.txt line 47; kontakt page |
+| Phone | `[REQUIRES CONFIRMATION]` — **no phone published anywhere** in the repo | (target: GBP, NAP, brief-form alternative contact §7.3) — see `decision-log.md` G1-2 |
+| Opening hours | `[REQUIRES CONFIRMATION]` — not published in repo | (target: GBP, `LocalBusiness` `openingHours`) — see G1-1 |
+
+## 4. Web & social profiles
+
+| Field | Value (from repo) | Where this fact appears |
+|---|---|---|
+| Website (BASE_URL) | **https://koolstudio.pl** | `lib/site.ts` `BASE_URL`; JSON-LD `url`; `metadataBase`; llms.txt |
+| Instagram | **https://www.instagram.com/kool.studio/** | `lib/site.ts` `INSTAGRAM_URL`; JSON-LD `sameAs`; llms.txt line 48; `FooterBar` |
+| LinkedIn | `[REQUIRES CONFIRMATION]` — playbook §3.1 cites `pl.linkedin.com/company/koolstudio`, but this URL is **not referenced anywhere in the repo** | (target: JSON-LD `sameAs`) — see G1-6 |
+| Google Business Profile URL | `[REQUIRES CONFIRMATION]` — only a `maps.app.goo.gl` share link exists; GBP ownership/claim status unknown | see G6-1 |
+| Bing Places | `[REQUIRES CONFIRMATION]` — not in repo | see G6-2 |
+| Other directories (Oferteo, etc.) | `[REQUIRES CONFIRMATION]` — §3.1 notes an Oferteo profile with unverified reviews; not a repo fact | verify before listing as `sameAs` |
+
+## 5. People (founders)
+
+| Field | Value (from repo) | Where this fact appears |
+|---|---|---|
+| Founder 1 | **Ola Kilińska** | JSON-LD `founder[]` (`layout.tsx`); `messages/*.json` (`meta.*.description`, `studio.heroImageAlt`, studio intro); llms.txt line 24 |
+| Founder 2 | **Ola Leszczyńska** | JSON-LD `founder[]`; `messages/*.json`; llms.txt line 24 |
+| Full legal names | `[REQUIRES CONFIRMATION]` — playbook §3.1 uses "Aleksandra Kilińska / Aleksandra Leszczyńska"; repo uses the diminutive "Ola". Reconcile before `Person` schema. | see G1-5 |
+| Roles | **architects** ("architektki" / "architects") | `messages/*.json` studio intro & meta descriptions; llms.txt |
+| Team size | `[REQUIRES CONFIRMATION]` — §3.1 reports "2–10" from LinkedIn (self-reported); **not** a repo fact — do not publish as objective | — |
+
+## 6. Business descriptors & service facts
+
+| Field | Value (from repo) | Where this fact appears |
+|---|---|---|
+| Schema type currently used | **`ProfessionalService`** | JSON-LD `@type` (`layout.tsx`) — ⚠ playbook §10.1 flags `ProfessionalService` as **deprecated**; migrate to `Organization` or `LocalBusiness` (pending G1-3). Flag, do not silently change. |
+| Entity `@id` | `https://koolstudio.pl/#studio` | JSON-LD `@id` |
+| Area served | **Wrocław, Warszawa, Poland** | JSON-LD `areaServed`; llms.txt "Service area: Wrocław, Warsaw, and all of Poland"; keywords |
+| Service types (schema) | Interior Architecture · Interior Design · Custom Furniture Design · Lighting Design · Visual Identity Design | JSON-LD `serviceType` |
+| Services (llms.txt prose) | Interior architecture (concept, construction documentation, author supervision) · Custom furniture · Custom lighting · Visual identity & branding · Uniform design · **Sanepid/sanitary-approval support** | llms.txt lines 34–40 |
+| Languages | **pl, en** | JSON-LD `knowsLanguage` |
+| Logo | `https://koolstudio.pl/logo.svg` | JSON-LD `logo`; `public/logo.svg` |
+| Brand image | `https://koolstudio.pl/images/studio/team.webp` | JSON-LD `image` |
+
+> **Flag for review (G5):** llms.txt asserts "Sanitary-approval (Sanepid) support for food-service venues" as a service. This is a competence claim that needs a named owner/reviewer before it is repeated on GBP or Services pages (see `decision-log.md` G5-3). It is included here only because the repo already publishes it — not as confirmation that it should stay.
+
+---
+
+## 7. Missing-fields checklist (blocks GBP / Bing / full entity graph)
+
+Resolve each in `decision-log.md`, then add it to every surface in one pass:
+
+- [ ] Phone number — G1-2
+- [ ] Opening hours (or "by appointment") — G1-1
+- [ ] Address reception policy (show vs hide on GBP) — G1-3
+- [ ] Legal name + registration numbers — G1-4
+- [ ] Founder full legal names (Ola vs Aleksandra) — G1-5
+- [ ] LinkedIn URL — G1-6
+- [ ] GBP ownership/claim + primary category — G6-1 (+ §9.1 category `[REQUIRES CONFIRMATION]`)
+- [ ] Bing Places ownership — G6-2
+
+## 8. Propagation checklist (when any confirmed fact changes)
+
+Update, in this order, and verify parity:
+
+1. `data/` / `lib/site.ts` / `messages/pl.json` + `messages/en.json` (keep PL/EN parity — `pnpm check:i18n`)
+2. JSON-LD block in `app/[locale]/layout.tsx`
+3. `app/llms.txt/route.ts` prose (note: project facts there are generated from `data/projects.ts`; NAP/contact block is hand-written)
+4. Google Business Profile
+5. Bing Places
+6. Any directory / `sameAs` profile
+7. Press kits (`press-kit-*.md`)
+
+Per playbook §9.1/§10.3, all seven must assert identical facts. A mismatch between visible content and JSON-LD is a production-gate failure.

--- a/docs/playbook/press-kit-dehesa.en.md
+++ b/docs/playbook/press-kit-dehesa.en.md
@@ -1,0 +1,148 @@
+# Press Kit — Dehesa Delicatessen (Wrocław) — DRAFT
+
+> **STATUS: DRAFT — DO NOT SEND.** Prepared solely from content published on koolstudio.pl (`data/projects.ts`, slug `delikatesy-dehesa`) and `data/press.ts`. Before any send, the following must be confirmed: photography rights, client consent scope, exclusivity/embargo status, and high-resolution file availability — see "Rights & status" and `decision-log.md` (gates G3, G6).
+>
+> Conformance with playbook §12.2: 600–900-word description ✅ · 120-word summary ✅ · project data sheet ✅ · full credits ✅ · studio bio + links ✅. **Still missing (to complete on rights clearance):** 15–25 high-res images + 5 vertical frames, plans/diagrams, material sheet, embargo status and press contact.
+
+---
+
+## Project description (EN, ~790 words)
+
+### A delicatessen straight out of an Almodóvar film — an Iberian concept in the heart of Wrocław
+
+In a sun-filled interior radiating warmth and authenticity, one finds the atmosphere of a traditional Spanish delicatessen. Dehesa is a small, 58-square-metre shop in Wrocław in which kool studio brought together the design of the space, the furniture, a custom lamp and a complete visual identity into one coherent story about produce and place.
+
+The starting point for the colour scheme was the films of Pedro Almodóvar — the palette drawn from them lends the space a contemporary character. The design combines sea navy, burgundy and yellow, complemented by strong red accents. The reds echo an old-school slicer, visible right from the entrance. Colour here is never decoration for its own sake: each hue marks out a different section of the shop and brings order to the interior, leading the customer through the successive zones of the offering.
+
+kool studio's scope here spanned the venue concept, the interior design, furniture design, the design of a custom lamp and construction documentation, as well as the visual identity and the uniform design. Dehesa is therefore a complete realisation — from the shell of the interior down to the smallest element of the brand's communication. It is precisely this multidisciplinary reach, rather than a single gesture, that defines the character of the place and makes it a representative example of a "brand + space" approach.
+
+### Material and light
+
+The interior is grounded in a timeless, uniform floor of custom-made terrazzo tiles. Their mix of aggregates and colours was composed specifically for this project, so the terrazzo becomes a quiet but consistent backdrop for the whole composition. The design deliberately juxtaposes raw materials — terrazzo, dark joinery and strong red accents — with the warmth of wood and the artisanal character of the produce itself. This tension between rawness and cosiness, between simplicity and richness of texture, defines Dehesa's mood.
+
+The heart of the deli is a vast counter. It is accentuated by decorative lamps designed especially for this interior and made by a Wrocław lighting manufacturer. Red arches, paired with delicate beige glass shades each crowned with a small sphere, lend the interior a retro charm. It is a detail that ties the aesthetic of the whole place together and becomes its recognisable signature.
+
+### The zones of the shop
+
+In a nod to traditional Spanish shops, the wall behind the counter is finished with decorative tiles in a classic black-and-white pattern. At its centre hangs a neon sign depicting the characteristic cuts of iberico pork — the most important part of the offering. Further along, Spain's signature long-cured jamón hams are displayed on steel rails.
+
+Conventional shop shelving was replaced by a built-in unit clad in small, irregular tiles in shades of beige, within which niches were designed. They hold carefully selected balsamic vinegars, olive oils, wines and other specialities that complement the offering at the counter. At the back of the shop, in a zone accented in burgundy, there is a section with high-quality frozen products and a small office nook. This colour break visually shortens the elongated interior and brings order to its depth.
+
+### The shopfront as a calling card
+
+Owing to the nearby car park and strong sunlight, a honey-toned wooden rack stands in front of the shop window. It serves a dual role: it is the venue's calling card and a screen against excessive sun. Crafted with attention to detail, its precise milled grooves allow the number of wooden louvres to be adjusted as needed — a practical detail that at the same time shapes the first impression from street level.
+
+### Visual identity and uniforms
+
+The concept was completed with a visual identity that keeps to a colour palette echoing the interior. The logotype recalls classic Spanish shop signs and is accompanied by a series of simple illustrations referencing the deli's principal products. The pig motif from the neon sign was carried over as a graphic onto printed materials, binding the visual communication to the architecture of the interior.
+
+That coherence reaches all the way to the staff's clothing. The uniforms — navy T-shirts paired with burgundy aprons finished with a subtle leather accent and yellow embroidery — harmonise with the shop's interior. Dehesa is in this way an example of kool studio's approach, in which the design of the interior, furniture, lighting and brand are created as one organism rather than separate layers: raw materials (terrazzo, dark joinery, red accents) meet the warmth of wood and the artisanal character of the produce, and a bespoke visual identity completes the whole.
+
+---
+
+## Summary (120 words)
+
+Dehesa is a 58-square-metre Iberian delicatessen in Wrocław (2023), designed by the Wrocław studio kool studio. An Almodóvar-inspired palette — sea navy, burgundy and yellow with strong red accents — organises the space: each colour marks out a different section of the shop. The interior is tied together by a uniform floor of custom-made terrazzo and a vast counter with bespoke lamps — red arches and beige glass shades made by a Wrocław lighting manufacturer. The wall behind the counter carries black-and-white tiles and a neon sign of iberico cuts, while long-cured jamón hams hang on steel rails. The project spanned the venue concept, interior, furniture, a lamp, construction documentation, visual identity and uniforms — a coherent example of a "brand + space" approach uniting architecture, product and communication.
+
+---
+
+## Project data sheet
+
+| Item | Detail |
+|---|---|
+| Name | Dehesa delicatessen |
+| Type | Iberian delicatessen / commercial interior (food retail) |
+| Location | Wrocław, Poland |
+| Area | 58 m² |
+| Year | 2023 |
+| Status | Completed |
+| Studio | kool studio, Wrocław |
+| Scope | venue concept · interior design · furniture design · lamp design · construction design · visual identity · uniform design |
+| Photography | Katarzyna Ramocka and Michał Woroniak \| ZASOBY STUDIO |
+| Lighting maker | a Wrocław lighting manufacturer (name `[TO CONFIRM]`) |
+| Project page | https://koolstudio.pl/en/projekty/delikatesy-dehesa |
+
+---
+
+## Image inventory
+
+Source files live in the repository at **`public/images/dehesa/`** (note: the folder is named `dehesa`, not `delikatesy-dehesa`). They are `.webp` files intended for the website — **high-resolution press versions are `[TO CONFIRM]`** (see "Rights & status"). Frame `01` is the hero image; frame `04` is used as the project thumbnail.
+
+The suggested captions below are **provisional** and must be paired with specific frames by the studio before sending — only elements documented in the published text are described; the content of individual photos is not guessed.
+
+| File | Role | Suggested press caption (to confirm) |
+|---|---|---|
+| `kool_dehesa_01.webp` | hero | Dehesa delicatessen in Wrocław — an interior inspired by the palette of Almodóvar's films. Design: kool studio. Photo: Katarzyna Ramocka and Michał Woroniak / ZASOBY STUDIO |
+| `kool_dehesa_02.webp` | — | The vast counter — heart of the deli — with bespoke red-arched lamps |
+| `kool_dehesa_03.webp` | — | Bespoke lighting: beige glass shades crowned with a sphere, paired with red arches |
+| `kool_dehesa_04.webp` | thumbnail | The wall behind the counter: black-and-white tiles and a neon sign of iberico pork cuts |
+| `kool_dehesa_05.webp` | — | Long-cured jamón hams displayed on steel rails |
+| `kool_dehesa_06.webp` | — | Built-in unit clad in small, irregular beige tiles, with niches replacing conventional shelving |
+| `kool_dehesa_07.webp` | — | Selected balsamic vinegars, olive oils and wines in the built-in niches |
+| `kool_dehesa_08.webp` | — | The uniform floor of custom-made terrazzo |
+| `kool_dehesa_09.webp` | — | The rear zone of the shop accented in burgundy |
+| `kool_dehesa_10.webp` | — | Colour detail — red, navy and yellow accents |
+| `kool_dehesa_11.webp` | — | Honey-toned wooden rack in front of the shopfront — calling card and sun screen |
+| `kool_dehesa_12.webp` | — | Adjustable wooden louvres of the shopfront |
+| `kool_dehesa_13.webp` | — | The pig neon / iberico motif within the interior |
+| `kool_dehesa_14.webp` | — | Visual identity recalling classic Spanish shop signs |
+| `kool_dehesa_15.webp` | — | Printed materials carrying the pig-neon motif |
+| `kool_dehesa_16.webp` | — | Uniforms: navy T-shirts and burgundy aprons with a leather accent and yellow embroidery |
+
+> **Vertical frames:** §12.2 requires at least 5 vertical images. In the gallery layout, frames 03, 06, 09, 10, 13 and 16 (among others) are treated as portrait — confirm which high-res versions are vertical.
+
+---
+
+## Studio bio
+
+kool studio is a Wrocław interior-architecture practice led by architects Ola Kilińska and Ola Leszczyńska. The studio designs distinctive residential and commercial interiors, working from Wrocław on projects across Poland. Its approach combines disciplines — from interior and furniture design, through lighting, to visual identity — creating coherent concepts in which brand and space are made as one whole. Dehesa is a representative example.
+
+*(Bio based solely on content published on koolstudio.pl. Full registration details and founder biographies are `[TO CONFIRM]` — see `nap-source-of-truth.md`.)*
+
+---
+
+## Official links
+
+- Project page: https://koolstudio.pl/en/projekty/delikatesy-dehesa
+- Studio: https://koolstudio.pl
+- Instagram: https://www.instagram.com/kool.studio/
+- Email: hello@koolstudio.pl
+
+**Existing coverage (from `data/press.ts`):**
+
+- Label Magazine — "Iberian delicatessen in Wrocław filled with colours from Almodóvar's films" (PL): https://label-magazine.com/wnetrza/artykuly/delikatesy-iberyjskie-we-wroclawiu-wypelnily-je-kolory-jak-z-filmow-almodovara
+- WhiteMAD (PL) — "Delicatessen in Wrocław — Dehesa": https://www.whitemad.pl/delikatesy-we-wroclawiu-dehesa/
+- WhiteMAD (EN, per playbook §3.1): https://www.whitemad.pl/en/delicatessen-in-wroclaw-inspired-by-the-colours-of-spain/
+
+---
+
+## Rights & status — `[TO CONFIRM]` (blocks send)
+
+| Item | Status |
+|---|---|
+| **Exclusivity / embargo** | `[TO CONFIRM]` — Dehesa has already been published (Label Magazine, WhiteMAD 2024). The material cannot be offered as "exclusive". Define the follow-up angle and any embargo for new outlets. |
+| **Client consent scope** | `[TO CONFIRM]` — confirm the Dehesa owner's consent for continued press distribution (venue name, photos, description). |
+| **Photography rights** | `[TO CONFIRM]` — licence and permission from the photographers (Katarzyna Ramocka, Michał Woroniak / ZASOBY STUDIO) for press redistribution and hi-res file supply. See `decision-log.md` G3-2. |
+| **Hi-res files** | `[TO CONFIRM]` — the repo holds only web `.webp`; assemble 15–25 hi-res images + 5 vertical. |
+| **Plans / material sheet** | `[TO CONFIRM]` — to be supplied by the studio. |
+| **Collaborator credits** | `[TO CONFIRM]` — confirm the name of the Wrocław lighting manufacturer; confirm all credits (§12.2). |
+| **Press contact / response owner** | `[TO CONFIRM]` — assign a PR lead + media contact address. |
+
+---
+
+## Target outlet list — `[PROPOSED]` (10)
+
+Selection to be approved by the PR lead; each pitch must be personalised, and each send + outcome recorded (§12.2). The order is not a ranking.
+
+| # | Outlet | Why it fits |
+|---|---|---|
+| 1 | ArchDaily | Global architecture/interiors reach; named directly in §12.1 as a Dehesa target; strong "one concept: interior + product + brand" angle. |
+| 2 | designboom | International design outlet that values bold colour and detail — the Almodóvar palette and the custom lamp resonate well. |
+| 3 | Frame | Specialises in retail/hospitality interiors; Dehesa as a small-format retail space with a strong identity. |
+| 4 | Dezeen | Large editorial reach; "brand + space" angle and artisanal detail (custom terrazzo, iberico neon). |
+| 5 | WhiteMAD (follow-up) | Published Dehesa in 2024 — a natural channel for an extended feature / new frames / the "brand + space" angle. |
+| 6 | Label Magazine | Already covered the project in Polish — good for an update that deepens the visual-identity thread. |
+| 7 | Design Alive | Polish premium design-and-brand outlet — fits the studio's multidisciplinary narrative. |
+| 8 | Architektura & Biznes | Polish architecture/interiors trade title — credible national recognition and link value. |
+| 9 | Hospitality/food-and-beverage design outlet (e.g. F&B design sections) | Dehesa as a delicatessen — a food-retail angle; pick the specific title for the target market. |
+| 10 | Wallpaper* | Prestigious lifestyle/design outlet; a "retro-Spanish concept with bespoke lighting" angle for the design/retail desk. |

--- a/docs/playbook/press-kit-dehesa.pl.md
+++ b/docs/playbook/press-kit-dehesa.pl.md
@@ -1,0 +1,148 @@
+# Zestaw prasowy — Delikatesy Dehesa (Wrocław) — DRAFT
+
+> **STATUS: SZKIC — NIE WYSYŁAĆ.** Materiał przygotowany wyłącznie na podstawie treści opublikowanych na koolstudio.pl (`data/projects.ts`, slug `delikatesy-dehesa`) oraz `data/press.ts`. Przed jakąkolwiek wysyłką muszą zostać potwierdzone: prawa do zdjęć, zakres zgody klienta, status wyłączności/embarga oraz dostępność plików w wysokiej rozdzielczości — patrz sekcja „Prawa i status" oraz `decision-log.md` (bramki G3, G6).
+>
+> Zgodność ze specyfikacją §12.2 playbooka: opis 600–900 słów ✅ · streszczenie 120 słów ✅ · karta projektu ✅ · pełne uznania autorstwa ✅ · biogram + linki ✅. **Brakuje (do uzupełnienia przy zwolnieniu praw):** 15–25 zdjęć w wysokiej rozdzielczości + 5 kadrów pionowych, rzuty/schematy, arkusz materiałowy, status embarga i osoba kontaktowa.
+
+---
+
+## Opis projektu (PL, ok. 640 słów)
+
+### Delikatesy jak z filmów Almodóvara — iberyjski koncept w sercu Wrocławia
+
+W pełnym słońca wnętrzu, emanującym ciepłem i autentycznością, można odnaleźć atmosferę tradycyjnych hiszpańskich delikatesów. Dehesa to niewielki, 58-metrowy sklep we Wrocławiu, w którym kool studio połączyło projekt przestrzeni, mebli, autorskiej lampy oraz kompletnej identyfikacji wizualnej w jedną, spójną opowieść o produkcie i miejscu.
+
+Punktem wyjścia dla kolorystyki stały się filmy Pedro Almodóvara — to z nich pochodzi paleta, która nadaje przestrzeni współczesny charakter. Projekt łączy barwy morskiego granatu, burgundu oraz żółci, uzupełnione o mocne akcenty czerwieni. Te ostatnie nawiązują do krajalnicy w oldschoolowym stylu, widocznej od razu po wejściu. Kolor nie jest tu dekoracją dla samej dekoracji — każda z barw odpowiada za poszczególne sekcje sklepu i porządkuje wnętrze, prowadząc klienta przez kolejne strefy oferty.
+
+Zakres prac kool studio objął tu koncept miejsca, projekt wnętrz, projekty mebli, projekt autorskiej lampy oraz projekt wykonawczy, a także identyfikację wizualną i projekt uniformów. Dehesa jest więc realizacją kompletną — od bryły wnętrza po najmniejszy element komunikacji marki. To właśnie ta wielodyscyplinarność, a nie pojedynczy gest, decyduje o charakterze miejsca i czyni z niego reprezentatywny przykład podejścia „marka + przestrzeń".
+
+### Materiał i światło
+
+Fundamentem wnętrza jest ponadczasowa, jednolita posadzka z wykonanych na zamówienie płytek lastryko. Mieszanka kruszyw i kolorów została dobrana specjalnie na potrzeby tego projektu, dzięki czemu terrazzo staje się cichym, ale konsekwentnym tłem dla całej kompozycji. Projekt świadomie zestawia surowe materiały — terrazzo, ciemną stolarkę i mocne, czerwone akcenty — z ciepłem drewna i rzemieślniczym charakterem samych produktów. To napięcie między surowością a przytulnością, między prostotą a bogactwem faktur, definiuje nastrój Dehesy.
+
+Sercem delikatesów jest ogromna lada. Podkreślają ją ozdobne lampy, zaprojektowane specjalnie dla tego wnętrza i wykonane przez wrocławskiego producenta oświetlenia. Czerwone łuki, w połączeniu z delikatnymi, szklanymi kloszami w beżowym odcieniu i zwieńczone subtelną kulką, dodają wnętrzu retro uroku. To detal, który spina estetykę całego miejsca i staje się jego rozpoznawalnym znakiem.
+
+### Strefy sklepu
+
+W nawiązaniu do tradycyjnych hiszpańskich sklepów ściana za ladą została wykończona dekoracyjnymi płytkami z klasycznym biało-czarnym wzorem. W jej centralnej części znajduje się neon prezentujący charakterystyczne cięcia wieprzowiny iberico — najważniejszą część oferty. Dalej, na stalowych relingach, eksponowane są typowe dla Hiszpanii, długo dojrzewające szynki jamón.
+
+Tradycyjne sklepowe regały zastąpiono zabudową z drobnych, nieregularnych płytek w odcieniach beżu, w której zaprojektowano wnęki. Mieszczą się w nich wyselekcjonowane octy balsamiczne, oliwy, wina oraz inne specjały, uzupełniające ofertę z lady. Na tyłach sklepu, w strefie zaakcentowanej kolorem burgundowym, znalazł się dział z wysokiej jakości produktami mrożonymi oraz niewielki aneks biurowy. Ten zabieg kolorystycznego odcięcia pozwolił optycznie skrócić podłużne wnętrze i uporządkować jego głębię.
+
+### Witryna jako wizytówka
+
+Ze względu na pobliski parking oraz mocne nasłonecznienie, przed witryną stanął drewniany regał w miodowym odcieniu. Pełni on podwójną funkcję: jest wizytówką miejsca oraz osłoną przed nadmiernym słońcem. Wykonany z dbałością o szczegóły, dzięki odpowiednim frezowaniom pozwala na regulację ilości drewnianych żaluzji w zależności od potrzeb — praktyczny detal, który jednocześnie buduje pierwsze wrażenie z poziomu ulicy.
+
+### Identyfikacja wizualna i uniformy
+
+Dopełnieniem konceptu był projekt identyfikacji wizualnej, zachowujący paletę kolorystyczną nawiązującą do wnętrza. Logotyp przywodzi na myśl klasyczne hiszpańskie szyldy i został uzupełniony o szereg prostych ilustracji, odnoszących się do głównych produktów z oferty deli. Motyw neonowej świni został przeniesiony w formie grafiki na elementy drukowane, spajając komunikację wizualną z architekturą wnętrza.
+
+Spójność sięga aż po ubiór obsługi. Uniformy — granatowe koszulki w połączeniu z burgundowymi fartuchami, wykończonymi delikatnym, skórzanym akcentem i żółtym haftem — współgrają z wnętrzem sklepu. Dehesa jest w ten sposób przykładem podejścia kool studio, w którym projekt wnętrza, mebli, oświetlenia i marki powstają jako jeden organizm, a nie osobne warstwy: surowe materiały (terrazzo, ciemna stolarka, czerwone akcenty) spotykają się z ciepłem drewna i rzemieślniczym charakterem produktów, a całość dopełnia autorska identyfikacja wizualna.
+
+---
+
+## Streszczenie (120 słów)
+
+Dehesa to 58-metrowe delikatesy iberyjskie we Wrocławiu (2023), zaprojektowane przez wrocławskie kool studio. Inspirowana filmami Almodóvara paleta — morski granat, burgund i żółć z mocnymi akcentami czerwieni — porządkuje przestrzeń: każdy kolor wyznacza inną sekcję sklepu. Wnętrze spina jednolita posadzka z wykonanego na zamówienie lastryko oraz ogromna lada z autorskimi lampami o czerwonych łukach i beżowych szklanych kloszach, wykonanymi przez wrocławskiego producenta oświetlenia. Ścianę za ladą zdobią biało-czarne płytki i neon z cięciami iberico, a długo dojrzewające szynki jamón wiszą na stalowych relingach. Projekt objął koncept miejsca, wnętrze, meble, lampę, dokumentację wykonawczą, identyfikację wizualną i uniformy — spójny przykład podejścia „marka + przestrzeń", w którym architektura, produkt i komunikacja powstają jako jedna całość.
+
+---
+
+## Karta projektu
+
+| Pozycja | Dane |
+|---|---|
+| Nazwa | Delikatesy Dehesa |
+| Typ | Delikatesy iberyjskie / wnętrze komercyjne (gastronomia/handel) |
+| Lokalizacja | Wrocław, Polska |
+| Powierzchnia | 58 m² |
+| Rok | 2023 |
+| Status | Zrealizowany |
+| Pracownia | kool studio, Wrocław |
+| Zakres | koncept miejsca · projekt wnętrz · projekty mebli · projekt lampy · projekt wykonawczy · identyfikacja wizualna · projekt uniformów |
+| Fotografie | Katarzyna Ramocka i Michał Woroniak \| ZASOBY STUDIO |
+| Producent oświetlenia | wrocławski producent oświetlenia (nazwa `[DO POTWIERDZENIA]`) |
+| Strona projektu | https://koolstudio.pl/pl/projekty/delikatesy-dehesa |
+
+---
+
+## Wykaz zdjęć
+
+Pliki źródłowe znajdują się w repozytorium w katalogu **`public/images/dehesa/`** (uwaga: katalog nosi nazwę `dehesa`, a nie `delikatesy-dehesa`). Są to pliki w formacie `.webp` przeznaczone na stronę WWW — **wersje w wysokiej rozdzielczości do prasy `[DO POTWIERDZENIA]`** (patrz sekcja „Prawa i status"). Kadr `01` jest zdjęciem głównym (hero), kadr `04` służy jako miniatura projektu.
+
+Proponowane podpisy poniżej są **wstępne** i muszą zostać sparowane z konkretnymi kadrami przez studio przed wysyłką — opisano wyłącznie elementy udokumentowane w opublikowanym tekście, bez zgadywania zawartości poszczególnych zdjęć.
+
+| Plik | Rola | Proponowany podpis prasowy (do potwierdzenia) |
+|---|---|---|
+| `kool_dehesa_01.webp` | hero | Delikatesy Dehesa we Wrocławiu — wnętrze inspirowane paletą z filmów Almodóvara. Proj. kool studio. Fot. Katarzyna Ramocka i Michał Woroniak / ZASOBY STUDIO |
+| `kool_dehesa_02.webp` | — | Ogromna lada — serce delikatesów — z autorskimi lampami o czerwonych łukach |
+| `kool_dehesa_03.webp` | — | Autorskie oświetlenie: beżowe szklane klosze zwieńczone kulką, w połączeniu z czerwonymi łukami |
+| `kool_dehesa_04.webp` | miniatura | Ściana za ladą z biało-czarnymi płytkami i neonem prezentującym cięcia wieprzowiny iberico |
+| `kool_dehesa_05.webp` | — | Długo dojrzewające szynki jamón eksponowane na stalowych relingach |
+| `kool_dehesa_06.webp` | — | Zabudowa z drobnych, nieregularnych beżowych płytek z wnękami zamiast klasycznych regałów |
+| `kool_dehesa_07.webp` | — | Wyselekcjonowane octy balsamiczne, oliwy i wina we wnękach zabudowy |
+| `kool_dehesa_08.webp` | — | Jednolita posadzka z wykonanego na zamówienie lastryko |
+| `kool_dehesa_09.webp` | — | Strefa na tyłach sklepu zaakcentowana kolorem burgundowym |
+| `kool_dehesa_10.webp` | — | Detal kolorystyczny — akcenty czerwieni, granatu i żółci |
+| `kool_dehesa_11.webp` | — | Drewniany regał w miodowym odcieniu przed witryną — wizytówka i osłona przed słońcem |
+| `kool_dehesa_12.webp` | — | Regulowane drewniane żaluzje witryny |
+| `kool_dehesa_13.webp` | — | Neon ze świnią / motyw iberico we wnętrzu |
+| `kool_dehesa_14.webp` | — | Identyfikacja wizualna nawiązująca do klasycznych hiszpańskich szyldów |
+| `kool_dehesa_15.webp` | — | Elementy drukowane z przeniesionym motywem neonowej świni |
+| `kool_dehesa_16.webp` | — | Uniformy: granatowe koszulki i burgundowe fartuchy ze skórzanym akcentem i żółtym haftem |
+
+> **Kadry pionowe:** §12.2 wymaga min. 5 zdjęć pionowych. W układzie galerii jako portretowe oznaczono m.in. kadry 03, 06, 09, 10, 13, 16 — do potwierdzenia, które wersje w wysokiej rozdzielczości są pionowe.
+
+---
+
+## Biogram studia
+
+kool studio to wrocławska pracownia architektury wnętrz, którą tworzą architektki Ola Kilińska i Ola Leszczyńska. Studio projektuje wyraziste wnętrza mieszkalne i komercyjne, działając z Wrocławia na projektach w całej Polsce. W swoim podejściu łączy dyscypliny — od projektowania wnętrz i mebli, przez oświetlenie, po identyfikację wizualną — tworząc spójne koncepcje, w których marka i przestrzeń powstają jako jedna całość. Dehesa jest tego reprezentatywnym przykładem.
+
+*(Biogram oparty wyłącznie na treściach opublikowanych na koolstudio.pl. Pełne dane rejestrowe i biografie założycielek — `[DO POTWIERDZENIA]`, patrz `nap-source-of-truth.md`.)*
+
+---
+
+## Oficjalne linki
+
+- Strona projektu: https://koolstudio.pl/pl/projekty/delikatesy-dehesa
+- Strona studia: https://koolstudio.pl
+- Instagram: https://www.instagram.com/kool.studio/
+- E-mail: hello@koolstudio.pl
+
+**Dotychczasowe publikacje (z `data/press.ts`):**
+
+- Label Magazine — „Delikatesy iberyjskie we Wrocławiu wypełniły je kolory jak z filmów Almodóvara": https://label-magazine.com/wnetrza/artykuly/delikatesy-iberyjskie-we-wroclawiu-wypelnily-je-kolory-jak-z-filmow-almodovara
+- WhiteMAD (PL) — „Delikatesy we Wrocławiu — Dehesa": https://www.whitemad.pl/delikatesy-we-wroclawiu-dehesa/
+- WhiteMAD (EN, wg §3.1 playbooka): https://www.whitemad.pl/en/delicatessen-in-wroclaw-inspired-by-the-colours-of-spain/
+
+---
+
+## Prawa i status — `[DO POTWIERDZENIA]` (blokuje wysyłkę)
+
+| Element | Status |
+|---|---|
+| **Wyłączność / embargo** | `[DO POTWIERDZENIA]` — Dehesa była już publikowana (Label Magazine, WhiteMAD 2024). Materiał nie może być oferowany jako „ekskluzywny". Ustalić kąt „follow-up" i ewentualne embargo dla nowych mediów. |
+| **Zakres zgody klienta** | `[DO POTWIERDZENIA]` — potwierdzić zgodę właściciela Dehesy na dalszą dystrybucję prasową (nazwa lokalu, zdjęcia, opis). |
+| **Prawa do zdjęć** | `[DO POTWIERDZENIA]` — licencja i zgoda fotografów (Katarzyna Ramocka, Michał Woroniak / ZASOBY STUDIO) na redystrybucję prasową i przekazanie plików hi-res. Patrz `decision-log.md` G3-2. |
+| **Pliki hi-res** | `[DO POTWIERDZENIA]` — w repo są tylko `.webp` na WWW; skompletować 15–25 zdjęć hi-res + 5 pionowych. |
+| **Rzuty / arkusz materiałowy** | `[DO POTWIERDZENIA]` — do dostarczenia przez studio. |
+| **Uznania współpracowników** | `[DO POTWIERDZENIA]` — potwierdzić nazwę wrocławskiego producenta oświetlenia; potwierdzić wszystkie kredyty (§12.2). |
+| **Osoba kontaktowa / właściciel odpowiedzi** | `[DO POTWIERDZENIA]` — wyznaczyć PR lead + adres kontaktowy dla mediów. |
+
+---
+
+## Lista docelowych redakcji — `[PROPOZYCJA]` (10)
+
+Dobór do zatwierdzenia przez PR lead; każdy pitch musi być spersonalizowany, a wysyłka i wynik odnotowane (§12.2). Kolejność nie jest rankingiem.
+
+| # | Redakcja | Dlaczego pasuje |
+|---|---|---|
+| 1 | ArchDaily | Globalny zasięg w architekturze/wnętrzach; wskazana wprost w §12.1 jako odbiorca Dehesy; mocny kąt „jeden koncept: wnętrze + produkt + marka". |
+| 2 | designboom | Międzynarodowe medium projektowe ceniące wyrazisty kolor i detal — paleta Almodóvara i autorska lampa dobrze rezonują. |
+| 3 | Frame | Specjalizacja w retail/hospitality interiors; Dehesa jako mały format handlowy o silnej tożsamości. |
+| 4 | Dezeen | Duży zasięg redakcyjny; kąt „brand + space" i rzemieślniczy detal (lastryko na zamówienie, neon iberico). |
+| 5 | WhiteMAD (follow-up) | Publikowała Dehesę w 2024 — naturalny kanał na materiał rozszerzony / nowe kadry / kąt „marka + przestrzeń". |
+| 6 | Label Magazine | Już opisała projekt po polsku — dobre do aktualizacji i pogłębienia wątku identyfikacji wizualnej. |
+| 7 | Design Alive | Polskie medium premium o designie i markach — pasuje do multidyscyplinarnej narracji studia. |
+| 8 | Architektura & Biznes | Polski tytuł branżowy (architektura/wnętrza) — wiarygodne uznanie krajowe i wartość linkowa. |
+| 9 | Medium hospitality/gastro (np. sekcje food & beverage design) | Dehesa jako delikatesy — kąt gastronomiczno-handlowy; dobrać konkretny tytuł do rynku docelowego. |
+| 10 | Wallpaper* | Prestiżowe medium lifestyle/design; kąt „retro-hiszpański koncept z autorskim oświetleniem" dla sekcji design/retail. |

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,190 @@
+// Privacy-safe GA4 event wrapper (SEO playbook §16.3).
+//
+// This module is a thin, defensive shim around `window.gtag`. It is INERT until
+// GA4 is configured: every helper no-ops when gtag has not been loaded (i.e. no
+// NEXT_PUBLIC_GA4_ID, so no <script> was injected). No helper ever throws and no
+// helper ever blocks navigation or form submission.
+//
+// HARD PRIVACY RULES (do not relax without a decision-log entry):
+//   - No PII, ever. No free-text field, no email/phone value, no reversible id.
+//   - No URLs carrying user input (query strings), no user-agent / geolocation.
+//   - Only the parameters enumerated per event below are ever sent.
+// The event_id used for brief de-duplication is a RANDOM UUID with no link to
+// any person — it exists purely so client + server measurement can be joined
+// without double-counting.
+//
+// Consent posture: GA4 loads with Consent Mode v2 defaults set to `denied` for
+// every storage signal (see components/GoogleAnalytics.tsx), so until a CMP
+// calls grantAnalyticsConsent() GA4 only sends cookieless pings. Decision-log
+// gate G4 (CMP choice) is still OPEN.
+
+type GtagArgs =
+  | ['event', string, Record<string, unknown>]
+  | ['consent', 'default' | 'update', Record<string, unknown>]
+  | ['config', string, Record<string, unknown>]
+  | ['js', Date];
+
+type GtagFn = (...args: GtagArgs[number][]) => void;
+
+declare global {
+  interface Window {
+    gtag?: GtagFn;
+    dataLayer?: unknown[];
+  }
+}
+
+// Coarse, non-identifying page categories. Derived from the route only — never
+// from a full URL, never from query input.
+export type PageType =
+  | 'home'
+  | 'services'
+  | 'service'
+  | 'projects'
+  | 'project'
+  | 'studio'
+  | 'contact'
+  | 'other';
+
+// True only when a GA4 property id is configured at build time. Instrumentation
+// setup (observers / listeners) is gated on this so the un-configured site adds
+// zero runtime behavior. NEXT_PUBLIC_ vars are statically inlined into the
+// client bundle, so this is identical on server and client (no hydration skew).
+export const analyticsEnabled: boolean = Boolean(process.env.NEXT_PUBLIC_GA4_ID);
+
+// Drop undefined keys so an optional param (e.g. `service`) is simply absent
+// rather than sent as `undefined`.
+function compact(params: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null && value !== '') out[key] = value;
+  }
+  return out;
+}
+
+// The single dispatch point. No-ops safely when gtag is missing; never throws.
+function sendEvent(name: string, params: Record<string, unknown>): void {
+  if (typeof window === 'undefined') return;
+  const gtag = window.gtag;
+  if (typeof gtag !== 'function') return;
+  try {
+    gtag('event', name, params);
+  } catch {
+    // Analytics must never break the page.
+  }
+}
+
+// A random, non-identifying id for brief de-duplication. crypto.randomUUID when
+// available; a non-crypto fallback otherwise (still carries no user data).
+function newEventId(): string {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+  } catch {
+    // fall through
+  }
+  return `evt-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 12)}`;
+}
+
+// Route -> page_type. Accepts a next-intl pathname (locale-stripped) but also
+// tolerates a leading /pl or /en. Only ever sees the path, never a query string.
+export function pageTypeFromPath(pathname: string): PageType {
+  const path = pathname.replace(/^\/(pl|en)(?=\/|$)/, '') || '/';
+  if (path === '/') return 'home';
+  if (path === '/kontakt') return 'contact';
+  if (path === '/studio') return 'studio';
+  if (path === '/oferta') return 'services';
+  if (path.startsWith('/oferta/')) return 'service';
+  if (path === '/projekty') return 'projects';
+  if (path.startsWith('/projekty/')) return 'project';
+  return 'other';
+}
+
+// --- Typed event helpers (allowed params ONLY) -------------------------------
+
+// cta_click {page_type, service?, cta_text, position}
+// cta_text is a static UI label (button/link chrome), never user input.
+export function trackCtaClick(params: {
+  page_type: PageType;
+  service?: string;
+  cta_text: string;
+  position: string;
+}): void {
+  sendEvent(
+    'cta_click',
+    compact({
+      page_type: params.page_type,
+      service: params.service,
+      cta_text: params.cta_text,
+      position: params.position,
+    })
+  );
+}
+
+// brief_start {page_path, service?} — first meaningful form interaction, once
+// per page view. page_path is a bare pathname (no query string).
+export function trackBriefStart(params: { page_path: string; service?: string }): void {
+  sendEvent(
+    'brief_start',
+    compact({ page_path: params.page_path, service: params.service })
+  );
+}
+
+// brief_submit {event_id, service?} — fires ONLY after a confirmed server-side
+// success. Generates a fresh random event_id per call and returns it.
+export function trackBriefSubmit(params?: { service?: string }): string {
+  const event_id = newEventId();
+  sendEvent('brief_submit', compact({ event_id, service: params?.service }));
+  return event_id;
+}
+
+// brief_mailto_fallback {event_id} — the mailto path, kept distinct from
+// brief_submit so a server delivery and a client-side fallback are never
+// conflated. Fresh random event_id per call, returned to the caller.
+export function trackBriefMailtoFallback(): string {
+  const event_id = newEventId();
+  sendEvent('brief_mailto_fallback', { event_id });
+  return event_id;
+}
+
+// email_click {page_type, position} — NEVER the address itself.
+export function trackEmailClick(params: { page_type: PageType; position: string }): void {
+  sendEvent('email_click', compact({ page_type: params.page_type, position: params.position }));
+}
+
+// case_engaged {case_id, service?} — a case-study section entered the viewport.
+// case_id is a project slug (public, non-PII).
+export function trackCaseEngaged(params: { case_id: string; service?: string }): void {
+  sendEvent(
+    'case_engaged',
+    compact({ case_id: params.case_id, service: params.service })
+  );
+}
+
+// --- Consent -----------------------------------------------------------------
+
+// Grant analytics_storage. Intended to be called by a future consent-management
+// platform (decision-log G4) once the visitor has opted in. Ad signals stay
+// denied — this site measures analytics only. No banner is built here.
+export function grantAnalyticsConsent(): void {
+  if (typeof window === 'undefined') return;
+  const gtag = window.gtag;
+  if (typeof gtag !== 'function') return;
+  try {
+    gtag('consent', 'update', { analytics_storage: 'granted' });
+  } catch {
+    // never throw
+  }
+}
+
+// Re-deny analytics_storage (e.g. the visitor withdraws consent).
+export function denyAnalyticsConsent(): void {
+  if (typeof window === 'undefined') return;
+  const gtag = window.gtag;
+  if (typeof gtag !== 'function') return;
+  try {
+    gtag('consent', 'update', { analytics_storage: 'denied' });
+  } catch {
+    // never throw
+  }
+}

--- a/lib/brief.ts
+++ b/lib/brief.ts
@@ -1,0 +1,320 @@
+// Pure, framework-agnostic logic for the project-brief form.
+// No 'use client' / 'use server' directive: this module is imported by the
+// server action (app/[locale]/kontakt/actions.ts), by the client form
+// (components/kontakt/BriefForm.tsx, types + option keys only) and by the
+// Node validation test (tests/brief-validation.test.ts). Keep it side-effect
+// free and dependency free so all three call sites stay in sync.
+
+// The studio inbox every brief is addressed to. Matches the published
+// contact email (footer + JSON-LD). Overridable at delivery time via
+// BRIEF_TO_EMAIL, but this is the honest default shown to users.
+export const BRIEF_CONTACT_EMAIL = 'hello@koolstudio.pl';
+
+// Minimum time (ms) a human is expected to spend before submitting. A submit
+// faster than this — with a roughly-synced clock — is treated as a bot.
+export const MIN_SUBMIT_MS = 3000;
+
+// Stable option keys submitted by the form. Display labels are localised in
+// messages/*.json (client) and mapped to canonical Polish below (email body).
+export const PROJECT_TYPES = ['mieszkanie', 'dom', 'komercyjne', 'inne'] as const;
+export const STAGES = [
+  'zakup',
+  'przed-zmianami',
+  'w-budowie',
+  'po-odbiorze',
+  'remont',
+] as const;
+export const SCOPE_ITEMS = [
+  'uklad-funkcjonalny',
+  'projekt-koncepcyjny',
+  'dokumentacja-wykonawcza',
+  'zabudowy-na-wymiar',
+  'zestawienia-wyceny',
+  'nadzor-autorski',
+] as const;
+
+export type ProjectType = (typeof PROJECT_TYPES)[number];
+export type Stage = (typeof STAGES)[number];
+export type ScopeItem = (typeof SCOPE_ITEMS)[number];
+
+// Text-length caps (characters). Server-enforced; the client also sets
+// maxLength for immediate feedback.
+export const LIMITS = {
+  name: 120,
+  email: 254,
+  location: 160,
+  area: 40,
+  startDate: 60,
+  completionDate: 60,
+  budget: 80,
+  priorities: 1000,
+  plansUrl: 600,
+} as const;
+
+export type BriefField =
+  | 'name'
+  | 'email'
+  | 'projectType'
+  | 'location'
+  | 'stage'
+  | 'area'
+  | 'startDate'
+  | 'completionDate'
+  | 'scope'
+  | 'budget'
+  | 'priorities'
+  | 'plansUrl';
+
+// Field order used for focus management, the email body and the success
+// render-back. Keeping one source of order avoids drift between the three.
+export const BRIEF_FIELD_ORDER: BriefField[] = [
+  'name',
+  'email',
+  'projectType',
+  'location',
+  'stage',
+  'area',
+  'startDate',
+  'completionDate',
+  'scope',
+  'budget',
+  'priorities',
+  'plansUrl',
+];
+
+export type BriefErrorCode = 'required' | 'email' | 'url' | 'tooLong' | 'option';
+
+// Raw, untrusted input (all strings from FormData; scope is multi-value).
+export interface BriefRawInput {
+  name?: string;
+  email?: string;
+  projectType?: string;
+  location?: string;
+  stage?: string;
+  area?: string;
+  startDate?: string;
+  completionDate?: string;
+  scope?: string[];
+  budget?: string;
+  priorities?: string;
+  plansUrl?: string;
+  company?: string; // honeypot — must stay empty
+  ts?: string; // form-render timestamp (ms since epoch)
+}
+
+// Normalised, trimmed values with scope narrowed to known keys.
+export interface NormalizedBrief {
+  name: string;
+  email: string;
+  projectType: string;
+  location: string;
+  stage: string;
+  area: string;
+  startDate: string;
+  completionDate: string;
+  scope: string[];
+  budget: string;
+  priorities: string;
+  plansUrl: string;
+}
+
+export interface BriefCheckResult {
+  // Honeypot filled or submitted implausibly fast. Reject silently.
+  spam: boolean;
+  // field -> error code (empty when valid)
+  errors: Partial<Record<BriefField, BriefErrorCode>>;
+  // trimmed + narrowed values, safe to email / render back
+  values: NormalizedBrief;
+}
+
+// Deliberately permissive shape check — never a full RFC validator, just
+// enough to catch obvious typos without rejecting valid addresses.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isValidHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function str(value: string | undefined): string {
+  return (value ?? '').trim();
+}
+
+/**
+ * Validate a raw brief submission. Pure and synchronous so it can be unit
+ * tested and reused server-side. Separates spam signals (honeypot / timing)
+ * from field-level errors, and returns normalised values either way.
+ */
+export function validateBrief(
+  input: BriefRawInput,
+  now: number = Date.now()
+): BriefCheckResult {
+  // --- spam signals ------------------------------------------------------
+  const honeypot = str(input.company);
+  const ts = Number(input.ts);
+  const elapsed = now - ts;
+  // Only reject when the elapsed time is a plausible, non-negative, too-small
+  // value. Missing/negative (clock skew, cached page) values are allowed
+  // through so genuine users are never blocked by the timing heuristic.
+  const tooFast = Number.isFinite(ts) && elapsed >= 0 && elapsed < MIN_SUBMIT_MS;
+  const spam = honeypot.length > 0 || tooFast;
+
+  // --- normalise ---------------------------------------------------------
+  const values: NormalizedBrief = {
+    name: str(input.name),
+    email: str(input.email),
+    projectType: str(input.projectType),
+    location: str(input.location),
+    stage: str(input.stage),
+    area: str(input.area),
+    startDate: str(input.startDate),
+    completionDate: str(input.completionDate),
+    scope: (input.scope ?? [])
+      .map((v) => v.trim())
+      .filter((v): v is ScopeItem => (SCOPE_ITEMS as readonly string[]).includes(v)),
+    budget: str(input.budget),
+    priorities: str(input.priorities),
+    plansUrl: str(input.plansUrl),
+  };
+
+  // --- field validation --------------------------------------------------
+  const errors: Partial<Record<BriefField, BriefErrorCode>> = {};
+
+  // name (required)
+  if (!values.name) errors.name = 'required';
+  else if (values.name.length > LIMITS.name) errors.name = 'tooLong';
+
+  // email (required + shape)
+  if (!values.email) errors.email = 'required';
+  else if (values.email.length > LIMITS.email) errors.email = 'tooLong';
+  else if (!EMAIL_RE.test(values.email)) errors.email = 'email';
+
+  // projectType (required + known option)
+  if (!values.projectType) errors.projectType = 'required';
+  else if (!(PROJECT_TYPES as readonly string[]).includes(values.projectType))
+    errors.projectType = 'option';
+
+  // location (optional, length)
+  if (values.location && values.location.length > LIMITS.location)
+    errors.location = 'tooLong';
+
+  // stage (optional, known option)
+  if (values.stage && !(STAGES as readonly string[]).includes(values.stage))
+    errors.stage = 'option';
+
+  // area (optional, length)
+  if (values.area && values.area.length > LIMITS.area) errors.area = 'tooLong';
+
+  // start / completion (optional, length)
+  if (values.startDate && values.startDate.length > LIMITS.startDate)
+    errors.startDate = 'tooLong';
+  if (values.completionDate && values.completionDate.length > LIMITS.completionDate)
+    errors.completionDate = 'tooLong';
+
+  // budget (optional, length)
+  if (values.budget && values.budget.length > LIMITS.budget) errors.budget = 'tooLong';
+
+  // priorities (optional, length)
+  if (values.priorities && values.priorities.length > LIMITS.priorities)
+    errors.priorities = 'tooLong';
+
+  // plansUrl (optional, length + http(s) shape)
+  if (values.plansUrl) {
+    if (values.plansUrl.length > LIMITS.plansUrl) errors.plansUrl = 'tooLong';
+    else if (!isValidHttpUrl(values.plansUrl)) errors.plansUrl = 'url';
+  }
+
+  return { spam, errors, values };
+}
+
+export function isBriefValid(result: BriefCheckResult): boolean {
+  return !result.spam && Object.keys(result.errors).length === 0;
+}
+
+// --- Canonical Polish labels for the email body -------------------------
+// The recipient is the studio (Polish). These are independent of the UI
+// locale so the delivered brief is deterministic and testable.
+export const PROJECT_TYPE_LABELS_PL: Record<string, string> = {
+  mieszkanie: 'mieszkanie',
+  dom: 'dom',
+  komercyjne: 'wnętrze komercyjne',
+  inne: 'inne',
+};
+
+export const STAGE_LABELS_PL: Record<string, string> = {
+  zakup: 'planuję zakup',
+  'przed-zmianami': 'przed zmianami lokatorskimi',
+  'w-budowie': 'w budowie',
+  'po-odbiorze': 'po odbiorze kluczy',
+  remont: 'remont istniejącego wnętrza',
+};
+
+export const SCOPE_LABELS_PL: Record<string, string> = {
+  'uklad-funkcjonalny': 'układ funkcjonalny',
+  'projekt-koncepcyjny': 'projekt koncepcyjny',
+  'dokumentacja-wykonawcza': 'dokumentacja wykonawcza',
+  'zabudowy-na-wymiar': 'zabudowy na wymiar',
+  'zestawienia-wyceny': 'zestawienia i wyceny',
+  'nadzor-autorski': 'nadzór autorski',
+};
+
+const FIELD_LABELS_PL: Record<BriefField, string> = {
+  name: 'Imię',
+  email: 'E-mail',
+  projectType: 'Typ projektu',
+  location: 'Lokalizacja',
+  stage: 'Etap projektu',
+  area: 'Przybliżona powierzchnia (m²)',
+  startDate: 'Pożądany start',
+  completionDate: 'Pożądane zakończenie',
+  scope: 'Oczekiwany zakres',
+  budget: 'Przybliżony budżet realizacji',
+  priorities: 'Priorytety (maks. 3)',
+  plansUrl: 'Link do rzutów / zdjęć',
+};
+
+const EMPTY = '—';
+
+function displayValue(field: BriefField, values: NormalizedBrief): string {
+  switch (field) {
+    case 'projectType':
+      return PROJECT_TYPE_LABELS_PL[values.projectType] ?? values.projectType ?? EMPTY;
+    case 'stage':
+      return values.stage ? (STAGE_LABELS_PL[values.stage] ?? values.stage) : EMPTY;
+    case 'scope':
+      return values.scope.length
+        ? values.scope.map((k) => SCOPE_LABELS_PL[k] ?? k).join(', ')
+        : EMPTY;
+    default: {
+      const v = values[field];
+      return typeof v === 'string' && v.length ? v : EMPTY;
+    }
+  }
+}
+
+export function buildBriefSubject(values: NormalizedBrief): string {
+  const type = PROJECT_TYPE_LABELS_PL[values.projectType] ?? values.projectType;
+  return `Brief projektowy — ${type || 'zapytanie'}`;
+}
+
+// Plain-text, structured body listing every field in a stable order.
+export function buildBriefText(values: NormalizedBrief): string {
+  const lines = BRIEF_FIELD_ORDER.map(
+    (field) => `${FIELD_LABELS_PL[field]}: ${displayValue(field, values)}`
+  );
+  return `${buildBriefSubject(values)}\n\n${lines.join('\n')}\n`;
+}
+
+// mailto: href addressed to the studio inbox, with the structured brief
+// prefilled. Used by the client fallback when server delivery is not
+// configured (or fails).
+export function buildMailtoHref(subject: string, body: string): string {
+  const params = new URLSearchParams({ subject, body });
+  // URLSearchParams encodes spaces as '+'; mail clients want %20 in the body.
+  const query = params.toString().replace(/\+/g, '%20');
+  return `mailto:${BRIEF_CONTACT_EMAIL}?${query}`;
+}

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -1,0 +1,171 @@
+// Server-safe Schema.org entity-graph builders for the whole site.
+//
+// Iron rule (SEO playbook): markup states only facts the site already
+// publishes — it never creates a new business fact. Every value here traces
+// to docs/playbook/nap-source-of-truth.md. Facts still marked
+// `[REQUIRES CONFIRMATION]` in docs/playbook/decision-log.md (phone, hours,
+// legal name, team size, the "Aleksandra" name form, offers/pricing/ratings)
+// must never appear below.
+import { BASE_URL, INSTAGRAM_URL } from './site';
+
+// Stable node identifiers — each entity is defined once per document and
+// referenced by @id everywhere else, and stays identical across the pl and en
+// documents (language variants describe the same entities, never duplicates).
+export const ORG_ID = `${BASE_URL}/#organization`;
+export const WEBSITE_ID = `${BASE_URL}/#website`;
+
+export function personId(slug: string) {
+  return `${BASE_URL}/#person-${slug}`;
+}
+
+// Founders exactly as the site itself names them (messages/*.json,
+// llms.txt): the diminutive "Ola", not the LinkedIn legal-name form which is
+// still unconfirmed (decision-log G1-5).
+const founders = [
+  { slug: 'ola-kilinska', name: 'Ola Kilińska' },
+  { slug: 'ola-leszczynska', name: 'Ola Leszczyńska' },
+] as const;
+
+// Role published on the studio page and meta descriptions ("architektki" /
+// "architects"); singular per-person form.
+function jobTitle(locale: string) {
+  return locale === 'en' ? 'architect' : 'architektka';
+}
+
+function founderNodes(locale: string) {
+  return founders.map((founder) => ({
+    '@type': 'Person',
+    '@id': personId(founder.slug),
+    name: founder.name,
+    jobTitle: jobTitle(locale),
+    worksFor: { '@id': ORG_ID },
+  }));
+}
+
+// LocalBusiness, not the deprecated ProfessionalService: the site already
+// publicly asserts a street address, geo and map link, so plain LocalBusiness
+// preserves the existing published claim while dropping the deprecated type.
+// Only already-published facts here — no phone, hours, priceRange,
+// aggregateRating, review, offers or hasOfferCatalog (decision-log G1/G2).
+function organizationNode(locale: string, description: string) {
+  return {
+    '@type': 'LocalBusiness',
+    '@id': ORG_ID,
+    name: 'Kool Studio',
+    description,
+    url: BASE_URL,
+    email: 'hello@koolstudio.pl',
+    logo: `${BASE_URL}/logo.svg`,
+    image: `${BASE_URL}/images/studio/team.webp`,
+    address: {
+      '@type': 'PostalAddress',
+      streetAddress: 'Zaporoska 83/15',
+      postalCode: '53-415',
+      addressLocality: 'Wrocław',
+      addressRegion: 'Dolnośląskie',
+      addressCountry: 'PL',
+    },
+    geo: {
+      '@type': 'GeoCoordinates',
+      latitude: 51.09168,
+      longitude: 17.01557,
+    },
+    hasMap: 'https://maps.app.goo.gl/f3nJEyLJXxKStLvPA',
+    // Published service-area claim: works from Wrocław on projects across
+    // Poland. Individual project cities are not service-area claims.
+    areaServed: [
+      { '@type': 'City', name: 'Wrocław' },
+      { '@type': 'Country', name: 'Poland' },
+    ],
+    serviceType: [
+      'Interior Architecture',
+      'Interior Design',
+      'Custom Furniture Design',
+      'Lighting Design',
+      'Visual Identity Design',
+    ],
+    knowsLanguage: ['pl', 'en'],
+    // Instagram (lib/site.ts) + the confirmed public LinkedIn company page.
+    sameAs: [INSTAGRAM_URL, 'https://pl.linkedin.com/company/koolstudio'],
+    founder: founders.map((founder) => ({ '@id': personId(founder.slug) })),
+  };
+}
+
+function websiteNode() {
+  return {
+    '@type': 'WebSite',
+    '@id': WEBSITE_ID,
+    name: 'Kool Studio',
+    url: BASE_URL,
+    publisher: { '@id': ORG_ID },
+    inLanguage: ['pl', 'en'],
+  };
+}
+
+// Site-wide graph emitted once per document from the root layout: the
+// organization, its founders and the website. Page-specific nodes (WebPage,
+// CreativeWork, BreadcrumbList, ImageObject) are emitted by the pages
+// themselves, so no @id is ever defined twice in one document.
+export function siteGraph(locale: string, description: string) {
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      organizationNode(locale, description),
+      ...founderNodes(locale),
+      websiteNode(),
+    ],
+  };
+}
+
+type Ref = { '@id': string };
+
+type WebPageInput = {
+  url: string;
+  name: string;
+  locale: string;
+  about?: Ref;
+  mainEntity?: Ref;
+  breadcrumb?: Ref;
+  primaryImageOfPage?: Ref;
+};
+
+// Reusable per-page WebPage node. @id is always the page's canonical URL +
+// #webpage, so it is unique per page and part of the shared #website.
+export function webPageNode({
+  url,
+  name,
+  locale,
+  about,
+  mainEntity,
+  breadcrumb,
+  primaryImageOfPage,
+}: WebPageInput) {
+  return {
+    '@type': 'WebPage',
+    '@id': `${url}#webpage`,
+    url,
+    name,
+    isPartOf: { '@id': WEBSITE_ID },
+    inLanguage: locale,
+    ...(about ? { about } : {}),
+    ...(mainEntity ? { mainEntity } : {}),
+    ...(breadcrumb ? { breadcrumb } : {}),
+    ...(primaryImageOfPage ? { primaryImageOfPage } : {}),
+  };
+}
+
+// BreadcrumbList whose items must mirror the visible <Breadcrumbs> trail
+// exactly (playbook: same hierarchy in UI and markup). Pass the same ordered
+// crumbs used to render the component, with absolute `url`s.
+export function breadcrumbList(id: string, items: { name: string; url: string }[]) {
+  return {
+    '@type': 'BreadcrumbList',
+    '@id': id,
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  };
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -77,6 +77,20 @@
     "wizualizacje": "VISUALIZATIONS",
     "zdjecia": "PHOTOS"
   },
+  "caseStudy": {
+    "sectionLabel": "Case study",
+    "challenge": "The challenge",
+    "decisions": "Design decisions",
+    "result": "The outcome",
+    "ctaText": "Facing a similar challenge? Tell us about your project.",
+    "ctaButton": "Fill in the project brief",
+    "serviceLinks": {
+      "projekt-mieszkania": "See how we design apartments",
+      "projekt-domu": "See how we design house interiors",
+      "wnetrza-komercyjne": "See how we design commercial interiors",
+      "oferta": "Explore our design services"
+    }
+  },
   "contact": {
     "cta": "READY TO START A PROJECT TOGETHER?"
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -11,7 +11,9 @@
     "section1Heading": "WE CREATE TIMELESS INTERIORS",
     "section1Text": "We design spaces that don't rely on trends. We treat each space individually, as an answer to a specific context and needs. Whether it's a residential or commercial project, we'll create an interior that tells your story.",
     "section2Heading": "WE DESIGN AT EVERY SCALE",
-    "section2Text": "We have years of experience in delivering projects of various character — from furniture details, through apartments and houses, to gastronomic, commercial and hotel venues. We manage the process comprehensively, with full control over the final result. This is how refined spaces are created, filled with original, unique elements. We are based in Wrocław and run projects across Poland — including Warsaw, Łódź and Gdańsk."
+    "section2Text": "We have years of experience in delivering projects of various character — from furniture details, through apartments and houses, to gastronomic, commercial and hotel venues. We manage the process comprehensively, with full control over the final result. This is how refined spaces are created, filled with original, unique elements. We are based in Wrocław and run projects across Poland — including Warsaw, Łódź and Gdańsk.",
+    "section1ImageAlt": "Moodboard of materials and finish samples in the Kool Studio workspace",
+    "section2ImageAlt": "Photograph of an interior designed by Kool Studio"
   },
   "meta": {
     "schemaDescription": "Wrocław-based interior architecture practice specializing in residential and commercial interiors, custom furniture, lighting design, and visual identity. Projects across Poland, including Warsaw.",
@@ -99,6 +101,12 @@
     "learnMore": "Learn more",
     "portfolio": "See our portfolio",
     "scopeTitle": "Scope of cooperation:",
+    "commercialImageAlt": "Restaurant interior designed by Kool Studio",
+    "commercialScopeImageAlt": "Storefront of a commercial space designed by Kool Studio",
+    "residentialImageAlt": "Living room in a Kool Studio residential project",
+    "residentialScopeImageAlt": "Kitchen in a Kool Studio residential project",
+    "materialsImageAlt": "Selection of finishing materials in a Kool Studio project",
+    "processImageAlt": "On-site author's supervision by Kool Studio",
     "commercial": {
       "label": "Commercial interiors",
       "heading": "Restaurants, concept stores, boutiques, hotels, services",

--- a/messages/en.json
+++ b/messages/en.json
@@ -42,6 +42,23 @@
       "title": "contact",
       "description": "Get in touch with Kool Studio — an interior architecture practice from Wrocław, Poland. Studio: Zaporoska 83/15, 53-415 Wrocław. Email: hello@koolstudio.pl.",
       "ogImageAlt": "Material and color palette in the Kool Studio workspace"
+    },
+    "services": {
+      "projekt-mieszkania": {
+        "title": "apartment interior design — wrocław",
+        "description": "We design premium apartments in Wrocław and across Poland — from the functional layout and tenant modifications, through construction documentation, to author's supervision.",
+        "ogImageAlt": "Apartment interior designed by Kool Studio"
+      },
+      "projekt-domu": {
+        "title": "house interior design — wrocław",
+        "description": "Premium house interior design — from concept and functional layout to construction documentation and author's supervision. Wrocław and all of Poland.",
+        "ogImageAlt": "Single-family house interior in Dobrzykowice designed by Kool Studio"
+      },
+      "wnetrza-komercyjne": {
+        "title": "commercial interiors — venue design",
+        "description": "Commercial interior design — restaurants, concept stores, boutiques, hotels and service venues. Concept, construction documentation, coordination of trades and author's supervision.",
+        "ogImageAlt": "Dehesa delicatessen interior designed by Kool Studio"
+      }
     }
   },
   "projects": {
@@ -160,6 +177,21 @@
       ],
       "bottomHeading": "We manage the process comprehensively from initial assumptions to the final result.",
       "bottomText": "We spread decisions over time, from general to specific, which allows us to capture all nuances and avoid random choices. We organize the entire process by eliminating doubts and, thanks to our experience, we facilitate decisions. This allows for a calm realization and a result consistent with the assumptions. As part of a comprehensive project, we support you at every stage."
+    }
+  },
+  "services": {
+    "hubHeading": "Explore the services in detail",
+    "sections": {
+      "recognition": "When it makes sense",
+      "scope": "Project scope",
+      "process": "Design process",
+      "proof": "Selected projects",
+      "faq": "Frequently asked questions"
+    },
+    "viewProject": "View project",
+    "cta": {
+      "heading": "Tell us about your project",
+      "button": "Get in touch"
     }
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -80,6 +80,106 @@
   "contact": {
     "cta": "READY TO START A PROJECT TOGETHER?"
   },
+  "brief": {
+    "heading": "TELL US ABOUT YOUR PROJECT",
+    "intro": "A short brief helps us prepare for the conversation. Fill in as much as you can — the more we know, the better we can respond.",
+    "requiredHint": "Fields marked with an asterisk (*) are required.",
+    "optionalTag": "optional",
+    "fields": {
+      "name": {
+        "label": "Name",
+        "help": "A first name is enough."
+      },
+      "email": {
+        "label": "Email",
+        "help": "We'll reply to this address."
+      },
+      "projectType": {
+        "label": "Project type",
+        "placeholder": "Choose…"
+      },
+      "location": {
+        "label": "Location",
+        "placeholder": "e.g. Wrocław",
+        "help": "The city is enough."
+      },
+      "stage": {
+        "label": "Project stage",
+        "placeholder": "Choose…"
+      },
+      "area": {
+        "label": "Approximate area (m²)",
+        "placeholder": "e.g. 85"
+      },
+      "startDate": {
+        "label": "Desired start",
+        "placeholder": "e.g. September 2026"
+      },
+      "completionDate": {
+        "label": "Desired completion",
+        "placeholder": "e.g. spring 2027"
+      },
+      "scope": {
+        "label": "Expected scope",
+        "help": "Tick what you're interested in."
+      },
+      "budget": {
+        "label": "Approximate implementation budget (optional)",
+        "help": "If you'd like, give a rough figure."
+      },
+      "priorities": {
+        "label": "Priorities",
+        "help": "What should work better than it does today? Max. 3 points."
+      },
+      "plansUrl": {
+        "label": "Link to plans or photos",
+        "placeholder": "https://…",
+        "help": "A link to a cloud folder. No file upload."
+      }
+    },
+    "projectTypeOptions": {
+      "mieszkanie": "apartment",
+      "dom": "house",
+      "komercyjne": "commercial interior",
+      "inne": "other"
+    },
+    "stageOptions": {
+      "zakup": "planning to buy",
+      "przed-zmianami": "before tenant modifications",
+      "w-budowie": "under construction",
+      "po-odbiorze": "after keys handover",
+      "remont": "renovation of an existing interior"
+    },
+    "scopeOptions": {
+      "uklad-funkcjonalny": "functional layout",
+      "projekt-koncepcyjny": "conceptual design",
+      "dokumentacja-wykonawcza": "construction documentation",
+      "zabudowy-na-wymiar": "custom cabinetry",
+      "zestawienia-wyceny": "specifications and quotes",
+      "nadzor-autorski": "author's supervision"
+    },
+    "honeypotLabel": "Leave this field empty",
+    "submit": "Send brief",
+    "sending": "Sending…",
+    "privacy": "Your details go solely to hello@koolstudio.pl and are used only to reply to this enquiry.",
+    "errors": {
+      "required": "This field is required.",
+      "email": "Enter a valid email address.",
+      "url": "Enter a valid URL (starting with http:// or https://).",
+      "tooLong": "This value is too long — please shorten it.",
+      "option": "Choose one of the available options.",
+      "summary": "Please fix the highlighted fields and submit again."
+    },
+    "status": {
+      "sending": "Sending the brief…",
+      "successTitle": "Thank you — your brief has been sent.",
+      "successNote": "We'll reply from hello@koolstudio.pl.",
+      "submittedHeading": "What you submitted",
+      "generic": "The form couldn't be sent. Please try again in a moment, or email hello@koolstudio.pl directly.",
+      "fallbackNote": "Your email app will open with the brief ready — send the message to complete your enquiry.",
+      "fallbackButton": "Open email app"
+    }
+  },
   "footer": {
     "banner": "WE ARE KOOL AND WE DESIGN KOOL THINGS!",
     "address": "STUDIO: ZAPOROSKA 83/15, WROCŁAW",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -42,6 +42,23 @@
       "title": "kontakt",
       "description": "Skontaktuj się z Kool Studio — pracownią architektury wnętrz z Wrocławia. Studio: Zaporoska 83/15, 53-415 Wrocław. E-mail: hello@koolstudio.pl.",
       "ogImageAlt": "Paleta materiałów i kolorów w pracowni Kool Studio"
+    },
+    "services": {
+      "projekt-mieszkania": {
+        "title": "projekt mieszkania — architektura wnętrz",
+        "description": "Projektujemy apartamenty o podwyższonym standardzie we Wrocławiu i całej Polsce — od układu funkcjonalnego i zmian lokatorskich, przez dokumentację wykonawczą, po nadzór autorski.",
+        "ogImageAlt": "Wnętrze mieszkania zaprojektowane przez Kool Studio"
+      },
+      "projekt-domu": {
+        "title": "projekt domu — architektura wnętrz",
+        "description": "Projekt wnętrz domu o podwyższonym standardzie — od koncepcji i układu funkcjonalnego po dokumentację wykonawczą i nadzór autorski. Wrocław i cała Polska.",
+        "ogImageAlt": "Wnętrze domu jednorodzinnego w Dobrzykowicach zaprojektowane przez Kool Studio"
+      },
+      "wnetrza-komercyjne": {
+        "title": "wnętrza komercyjne — projektowanie lokali",
+        "description": "Projektowanie wnętrz komercyjnych — restauracje, concept store'y, butiki, hotele i lokale usługowe. Koncepcja, dokumentacja wykonawcza, koordynacja branż i nadzór autorski.",
+        "ogImageAlt": "Wnętrze delikatesów Dehesa zaprojektowane przez Kool Studio"
+      }
     }
   },
   "projects": {
@@ -160,6 +177,21 @@
       ],
       "bottomHeading": "Prowadzimy proces kompleksowo od pierwszych założeń po finalny efekt.",
       "bottomText": "Decyzje rozkładamy w czasie, od ogółu do szczegółu, co pozwala uchwycić wszystkie niuanse i uniknąć przypadkowych wyborów. Porządkujemy cały proces eliminując wątpliwości i dzięki naszemu doświadczeniu, ułatwiamy decyzje. Pozwala to na spokojną realizację i efekt zgodny z założeniami. W ramach projektu kompleksowego wspieramy was na każdym jego etapie."
+    }
+  },
+  "services": {
+    "hubHeading": "Poznaj szczegóły oferty",
+    "sections": {
+      "recognition": "Kiedy warto",
+      "scope": "Zakres projektu",
+      "process": "Proces projektowy",
+      "proof": "Wybrane realizacje",
+      "faq": "Najczęstsze pytania"
+    },
+    "viewProject": "Zobacz projekt",
+    "cta": {
+      "heading": "Opowiedz nam o swoim projekcie",
+      "button": "Napisz do nas"
     }
   }
 }

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -11,7 +11,9 @@
     "section1Heading": "TWORZYMY PONADCZASOWE WNĘTRZA",
     "section1Text": "Projektujemy miejsca, które nie opierają się na trendach. Każdą przestrzeń traktujemy indywidualnie, jako odpowiedź na konkretny kontekst oraz potrzeby. Niezależnie, czy jest to projekt mieszkalny, czy komercyjny, stworzymy wnętrze, które opowie twoją historię.",
     "section2Heading": "PROJEKTUJEMY\nW KAŻDEJ SKALI",
-    "section2Text": "Posiadamy wieloletnie doświadczenie w realizowaniu projektów o różnym charakterze – od detalu mebla, przez mieszkania i domy, po obiekty gastronomiczne, komercyjne i hotele. Prowadzimy proces kompleksowo, z pełną kontrolą nad efektem końcowym. W ten sposób powstają dopracowane przestrzenie, wypełnione autorskimi, unikatowymi elementami. Pracujemy we Wrocławiu, a projekty prowadzimy w całej Polsce – m.in. w Warszawie, Łodzi i Gdańsku."
+    "section2Text": "Posiadamy wieloletnie doświadczenie w realizowaniu projektów o różnym charakterze – od detalu mebla, przez mieszkania i domy, po obiekty gastronomiczne, komercyjne i hotele. Prowadzimy proces kompleksowo, z pełną kontrolą nad efektem końcowym. W ten sposób powstają dopracowane przestrzenie, wypełnione autorskimi, unikatowymi elementami. Pracujemy we Wrocławiu, a projekty prowadzimy w całej Polsce – m.in. w Warszawie, Łodzi i Gdańsku.",
+    "section1ImageAlt": "Moodboard materiałów i próbek wykończeń w pracowni Kool Studio",
+    "section2ImageAlt": "Fotografia wnętrza zaprojektowanego przez Kool Studio"
   },
   "meta": {
     "schemaDescription": "Wrocławska pracownia architektury wnętrz projektująca wnętrza mieszkalne i komercyjne, autorskie meble, oświetlenie i identyfikację wizualną. Projekty w całej Polsce, m.in. w Warszawie.",
@@ -99,6 +101,12 @@
     "learnMore": "Dowiedz się więcej",
     "portfolio": "Zobacz nasze portfolio",
     "scopeTitle": "Zakres współpracy:",
+    "commercialImageAlt": "Wnętrze restauracji zaprojektowane przez Kool Studio",
+    "commercialScopeImageAlt": "Witryna lokalu komercyjnego zaprojektowanego przez Kool Studio",
+    "residentialImageAlt": "Salon w projekcie mieszkalnym Kool Studio",
+    "residentialScopeImageAlt": "Kuchnia w projekcie mieszkalnym Kool Studio",
+    "materialsImageAlt": "Dobór materiałów wykończeniowych w projekcie Kool Studio",
+    "processImageAlt": "Nadzór autorski na budowie prowadzony przez Kool Studio",
     "commercial": {
       "label": "Wnętrza komercyjne",
       "heading": "Restauracje, concept store'y, butiki, hotele, usługi",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -77,6 +77,20 @@
     "wizualizacje": "WIZUALIZACJE",
     "zdjecia": "ZDJĘCIA"
   },
+  "caseStudy": {
+    "sectionLabel": "Studium przypadku",
+    "challenge": "Wyzwanie",
+    "decisions": "Decyzje projektowe",
+    "result": "Efekt",
+    "ctaText": "Masz podobne wyzwanie? Opowiedz nam o swoim projekcie.",
+    "ctaButton": "Wypełnij brief projektowy",
+    "serviceLinks": {
+      "projekt-mieszkania": "Zobacz, jak projektujemy mieszkania",
+      "projekt-domu": "Zobacz, jak projektujemy wnętrza domów",
+      "wnetrza-komercyjne": "Zobacz, jak projektujemy wnętrza komercyjne",
+      "oferta": "Poznaj naszą ofertę projektową"
+    }
+  },
   "contact": {
     "cta": "GOTOWI, BY ZACZĄĆ WSPÓLNY PROJEKT?"
   },

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -80,6 +80,106 @@
   "contact": {
     "cta": "GOTOWI, BY ZACZĄĆ WSPÓLNY PROJEKT?"
   },
+  "brief": {
+    "heading": "OPOWIEDZ NAM O SWOIM PROJEKCIE",
+    "intro": "Krótki brief pomoże nam przygotować się do rozmowy. Wypełnij tyle, ile możesz — im więcej wiemy, tym trafniej odpowiemy.",
+    "requiredHint": "Pola oznaczone gwiazdką (*) są wymagane.",
+    "optionalTag": "opcjonalnie",
+    "fields": {
+      "name": {
+        "label": "Imię",
+        "help": "Wystarczy imię."
+      },
+      "email": {
+        "label": "E-mail",
+        "help": "Na ten adres odpiszemy."
+      },
+      "projectType": {
+        "label": "Typ projektu",
+        "placeholder": "Wybierz…"
+      },
+      "location": {
+        "label": "Lokalizacja",
+        "placeholder": "np. Wrocław",
+        "help": "Wystarczy miasto."
+      },
+      "stage": {
+        "label": "Etap projektu",
+        "placeholder": "Wybierz…"
+      },
+      "area": {
+        "label": "Przybliżona powierzchnia (m²)",
+        "placeholder": "np. 85"
+      },
+      "startDate": {
+        "label": "Pożądany start",
+        "placeholder": "np. wrzesień 2026"
+      },
+      "completionDate": {
+        "label": "Pożądane zakończenie",
+        "placeholder": "np. wiosna 2027"
+      },
+      "scope": {
+        "label": "Oczekiwany zakres",
+        "help": "Zaznacz, co Cię interesuje."
+      },
+      "budget": {
+        "label": "Przybliżony budżet realizacji (opcjonalnie)",
+        "help": "Jeśli chcesz, podaj orientacyjną kwotę."
+      },
+      "priorities": {
+        "label": "Priorytety",
+        "help": "Co powinno działać lepiej niż dziś? Maks. 3 punkty."
+      },
+      "plansUrl": {
+        "label": "Link do rzutów lub zdjęć",
+        "placeholder": "https://…",
+        "help": "Link do folderu w chmurze. Bez przesyłania plików."
+      }
+    },
+    "projectTypeOptions": {
+      "mieszkanie": "mieszkanie",
+      "dom": "dom",
+      "komercyjne": "wnętrze komercyjne",
+      "inne": "inne"
+    },
+    "stageOptions": {
+      "zakup": "planuję zakup",
+      "przed-zmianami": "przed zmianami lokatorskimi",
+      "w-budowie": "w budowie",
+      "po-odbiorze": "po odbiorze kluczy",
+      "remont": "remont istniejącego wnętrza"
+    },
+    "scopeOptions": {
+      "uklad-funkcjonalny": "układ funkcjonalny",
+      "projekt-koncepcyjny": "projekt koncepcyjny",
+      "dokumentacja-wykonawcza": "dokumentacja wykonawcza",
+      "zabudowy-na-wymiar": "zabudowy na wymiar",
+      "zestawienia-wyceny": "zestawienia i wyceny",
+      "nadzor-autorski": "nadzór autorski"
+    },
+    "honeypotLabel": "Zostaw to pole puste",
+    "submit": "Wyślij brief",
+    "sending": "Wysyłanie…",
+    "privacy": "Twoje dane trafiają wyłącznie na hello@koolstudio.pl i służą jedynie do odpowiedzi na to zapytanie.",
+    "errors": {
+      "required": "To pole jest wymagane.",
+      "email": "Podaj poprawny adres e-mail.",
+      "url": "Podaj poprawny adres URL (zaczynający się od http:// lub https://).",
+      "tooLong": "Wpisano zbyt długą wartość — skróć ją.",
+      "option": "Wybierz jedną z dostępnych opcji.",
+      "summary": "Popraw zaznaczone pola i wyślij ponownie."
+    },
+    "status": {
+      "sending": "Wysyłanie briefu…",
+      "successTitle": "Dziękujemy — brief został wysłany.",
+      "successNote": "Odpowiedź wyślemy z adresu hello@koolstudio.pl.",
+      "submittedHeading": "Przesłane informacje",
+      "generic": "Nie udało się wysłać formularza. Spróbuj ponownie za chwilę lub napisz bezpośrednio na hello@koolstudio.pl.",
+      "fallbackNote": "Otworzy się Twój program pocztowy z gotowym briefem — wyślij wiadomość, aby dokończyć zgłoszenie.",
+      "fallbackButton": "Otwórz program pocztowy"
+    }
+  },
   "footer": {
     "banner": "WE ARE KOOL AND WE DESIGN KOOL THINGS!",
     "address": "STUDIO: ZAPOROSKA 83/15, WROCŁAW",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "kool-v2",
   "version": "1.0.0",
+  "packageManager": "pnpm@10.33.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port ${CONDUCTOR_PORT:-8080}",

--- a/tests/brief-validation.test.ts
+++ b/tests/brief-validation.test.ts
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  validateBrief,
+  isBriefValid,
+  buildBriefSubject,
+  buildBriefText,
+  buildMailtoHref,
+  MIN_SUBMIT_MS,
+  BRIEF_CONTACT_EMAIL,
+  type BriefRawInput,
+} from '../lib/brief.ts';
+
+// A fixed clock so the timing heuristic is deterministic.
+const NOW = 1_800_000_000_000;
+
+// A complete, well-formed submission that passes every rule. ts is old enough
+// to clear the minimum-time check.
+function validInput(overrides: Partial<BriefRawInput> = {}): BriefRawInput {
+  return {
+    name: 'Ola',
+    email: 'ola@example.com',
+    projectType: 'mieszkanie',
+    location: 'Wrocław',
+    stage: 'po-odbiorze',
+    area: '85',
+    startDate: 'wrzesień 2026',
+    completionDate: 'wiosna 2027',
+    scope: ['uklad-funkcjonalny', 'nadzor-autorski'],
+    budget: '200 000 zł',
+    priorities: 'Więcej światła; cichsza sypialnia; miejsce do pracy.',
+    plansUrl: 'https://drive.example.com/folder',
+    company: '',
+    ts: String(NOW - 10_000),
+    ...overrides,
+  };
+}
+
+test('valid input passes with no errors and no spam flag', () => {
+  const result = validateBrief(validInput(), NOW);
+  assert.equal(result.spam, false);
+  assert.deepEqual(result.errors, {});
+  assert.equal(isBriefValid(result), true);
+  // scope preserved
+  assert.deepEqual(result.values.scope, ['uklad-funkcjonalny', 'nadzor-autorski']);
+});
+
+test('missing email is a required error', () => {
+  const result = validateBrief(validInput({ email: '' }), NOW);
+  assert.equal(result.errors.email, 'required');
+  assert.equal(isBriefValid(result), false);
+});
+
+test('malformed email is an email-shape error', () => {
+  const result = validateBrief(validInput({ email: 'not-an-email' }), NOW);
+  assert.equal(result.errors.email, 'email');
+  assert.equal(isBriefValid(result), false);
+});
+
+test('missing name is a required error', () => {
+  const result = validateBrief(validInput({ name: '   ' }), NOW);
+  assert.equal(result.errors.name, 'required');
+});
+
+test('missing project type is a required error', () => {
+  const result = validateBrief(validInput({ projectType: '' }), NOW);
+  assert.equal(result.errors.projectType, 'required');
+});
+
+test('unknown project type is an option error', () => {
+  const result = validateBrief(validInput({ projectType: 'hacked' }), NOW);
+  assert.equal(result.errors.projectType, 'option');
+});
+
+test('honeypot field filled flags spam (and blocks validity)', () => {
+  const result = validateBrief(validInput({ company: 'http://spam.example' }), NOW);
+  assert.equal(result.spam, true);
+  assert.equal(isBriefValid(result), false);
+});
+
+test('too-fast submit (under the minimum) flags spam', () => {
+  const result = validateBrief(validInput({ ts: String(NOW - (MIN_SUBMIT_MS - 500)) }), NOW);
+  assert.equal(result.spam, true);
+  assert.equal(isBriefValid(result), false);
+});
+
+test('a slow-enough submit is not spam', () => {
+  const result = validateBrief(validInput({ ts: String(NOW - (MIN_SUBMIT_MS + 500)) }), NOW);
+  assert.equal(result.spam, false);
+});
+
+test('missing/negative timestamp is not treated as too-fast (no false block)', () => {
+  assert.equal(validateBrief(validInput({ ts: '' }), NOW).spam, false);
+  // clock skew: client ahead of server -> negative elapsed -> allowed through
+  assert.equal(validateBrief(validInput({ ts: String(NOW + 5000) }), NOW).spam, false);
+});
+
+test('malformed plans URL is a url error; a valid http(s) URL passes', () => {
+  assert.equal(validateBrief(validInput({ plansUrl: 'drive.example.com' }), NOW).errors.plansUrl, 'url');
+  assert.equal(validateBrief(validInput({ plansUrl: 'javascript:alert(1)' }), NOW).errors.plansUrl, 'url');
+  assert.equal(validateBrief(validInput({ plansUrl: 'http://ok.example' }), NOW).errors.plansUrl, undefined);
+  assert.equal(validateBrief(validInput({ plansUrl: '' }), NOW).errors.plansUrl, undefined);
+});
+
+test('over-long values are tooLong errors', () => {
+  const result = validateBrief(validInput({ name: 'x'.repeat(200) }), NOW);
+  assert.equal(result.errors.name, 'tooLong');
+});
+
+test('unknown scope keys are dropped, known ones kept', () => {
+  const result = validateBrief(
+    validInput({ scope: ['uklad-funkcjonalny', 'tampered', 'zestawienia-wyceny'] }),
+    NOW
+  );
+  assert.deepEqual(result.values.scope, ['uklad-funkcjonalny', 'zestawienia-wyceny']);
+});
+
+test('subject and body are structured and use canonical Polish labels', () => {
+  const { values } = validateBrief(validInput(), NOW);
+  assert.equal(buildBriefSubject(values), 'Brief projektowy — mieszkanie');
+  const body = buildBriefText(values);
+  assert.match(body, /^Brief projektowy — mieszkanie/);
+  assert.match(body, /Imię: Ola/);
+  assert.match(body, /E-mail: ola@example\.com/);
+  assert.match(body, /Etap projektu: po odbiorze kluczy/);
+  assert.match(body, /Oczekiwany zakres: układ funkcjonalny, nadzór autorski/);
+  // empty optional fields render as em dash
+  const sparse = validateBrief(
+    { name: 'A', email: 'a@b.co', projectType: 'inne', ts: String(NOW - 10_000) },
+    NOW
+  ).values;
+  assert.match(buildBriefText(sparse), /Lokalizacja: —/);
+});
+
+test('mailto href targets the studio inbox with encoded subject and body', () => {
+  const { values } = validateBrief(validInput(), NOW);
+  const href = buildMailtoHref(buildBriefSubject(values), buildBriefText(values));
+  assert.ok(href.startsWith(`mailto:${BRIEF_CONTACT_EMAIL}?`));
+  assert.match(href, /subject=Brief%20projektowy/);
+  assert.doesNotMatch(href, /\s/); // fully encoded, no raw whitespace
+});


### PR DESCRIPTION
Implements the buildable core of the kool studio SEO / AI-visibility / qualified-lead playbook, in 8 reviewable commits. Everything ships in both locales (pl canonical + en), and **no unconfirmed business fact appears anywhere** — every claim traces to copy the site already publishes; every missing fact is logged in `docs/playbook/decision-log.md` instead of invented.

## What's in here

**1. Playbook ops docs** (`docs/playbook/`)
Decision log (30 gate decisions + 26 FAQ facts awaiting owner sign-off), NAP source-of-truth sheet, quarterly AI-audit kit (30 PL + 10 EN fixed prompts with protocol and scoring sheet), Dehesa press-kit drafts (PL+EN, marked do-not-send until rights clear), and a B01–B12 backlog status board.

**2. Technical SEO foundation**
Removed fabricated sitemap freshness (`lastModified: new Date()` each build) and unsubstantiated `changeFrequency`; completed project-page metadata (twitter card, og:image alt/siteName/url); replaced every generic or hardcoded-English image alt with truthful localized patterns; fixed a real 2× image overfetch in `BeforeAfterSlider` (`sizes` said 100vw at a 50vw render). Canonical + reciprocal hreflang + x-default verified in built HTML.

**3. JSON-LD entity graph** (`lib/schema.ts`)
The deprecated `ProfessionalService` markup is replaced by a stable-`@id` graph: `LocalBusiness` #organization (published facts only), founder `Person` nodes, `WebSite`, per-page `WebPage`, per-project `CreativeWork` + `ImageObject` with photographer credit, and `BreadcrumbList` that mirrors a new visible breadcrumb component exactly. No phone/hours/prices/ratings/offers — all unconfirmed.

**4. Services hub + three landing pages**
`/oferta` gains a crawlable links block; new indexable routes `/oferta/projekt-mieszkania`, `/oferta/projekt-domu`, `/oferta/wnetrza-komercyjne` with a 7-section template (hero, recognition, scope, process, proof, FAQ, CTA). Scope lists and the 7 process steps stay single-sourced from the existing `oferta.*` messages; proof cards come from `data/projects.ts`; FAQs are accessible accordions with server-rendered content and only educational / it-depends answers.

**5. Qualifying project-brief form** (`/kontakt`)
Playbook §7.1 fields grounded in published service truth. Accessible (labels, aria-describedby, focus-to-first-error, aria-live), honeypot + min-time spam checks, 15 validation tests. Delivery is pluggable: Resend REST when `RESEND_API_KEY` is set, otherwise a prefilled `mailto:hello@koolstudio.pl` fallback so the form is useful today with zero config (`.env.example` documents the vars). No SLA/budget-band/privacy-policy claims.

**6. Case-study depth**
`Project` gains an optional `caseStudy {problem, decisions, result}` block — populated for 11 of 15 projects strictly by restructuring each project's already-published description (4 with placeholder/atmospheric copy honestly excluded). Rendered as a structured section on detail pages, plus case→service cross-links and a brief CTA completing the internal-linking loop. ADHD-related wording on Strachowicka kept verbatim; competition projects stay labeled as concepts.

**7. Analytics scaffold (inert until configured)**
`lib/analytics.ts` + loader gated on `NEXT_PUBLIC_GA4_ID` — with the var unset the build contains zero gtag references (verified). When enabled: Consent Mode v2 defaults all-denied before config, and a strict no-PII event dictionary (`cta_click`, `brief_start`, `brief_submit`, `brief_mailto_fallback`, `email_click`, `case_engaged`) instrumented via data-attribute delegation so server components stay server. Event spec + business handoff in `docs/playbook/analytics-events.md`.

**8. CLAUDE.md / housekeeping** — docs updated for the new structure; `.context/` gitignored.

## Verification

- `pnpm check` green at every phase: vitest 15 + node --test 27, typecheck, lint, i18n parity (201 keys), production build (54 static pages).
- Browser QA over all 48 routes (both locales): 48/48 HTTP 200, FAQ accordions toggle, brief form renders, screenshots reviewed. Only console errors are the pre-existing Vercel Analytics scripts blocked by the QA sandbox's egress proxy (fine in production); known non-gating dev warnings: pre-existing `dot.svg` CSS aspect-ratio hint and `next/image` LCP `priority` suggestions on some listing images.

## What this deliberately does NOT do

Publish prices, hours, phone, SLAs, review markup, or any service/location claim not already on the site; create GBP/Bing/GA4/GSC accounts; send press kits; add a cookie banner (CMP choice pending). The owner-decision queue for all of that is `docs/playbook/decision-log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QyM7GMirWZvVRkJWpzedPQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QyM7GMirWZvVRkJWpzedPQ)_