### PR TITLE
Eliminate homepage hero CLS (0.46 → 0)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -66,6 +66,26 @@ body {
   transition-timing-function: cubic-bezier(0.33, 1, 0.68, 1);
 }
 
+/* Pre-init slide sizing must mirror slidesPerView/spaceBetween in
+   ImageStrip.tsx, so Swiper's JS init doesn't reflow the strip (CLS) */
+.hero-swiper:not(.swiper-initialized) .swiper-slide {
+  width: 100%;
+  margin-right: 3px;
+  flex-shrink: 0;
+}
+
+@media (min-width: 768px) {
+  .hero-swiper:not(.swiper-initialized) .swiper-slide {
+    width: calc((100% - 3px) / 2);
+  }
+}
+
+@media (min-width: 1280px) {
+  .hero-swiper:not(.swiper-initialized) .swiper-slide {
+    width: calc((100% - 6px) / 3);
+  }
+}
+
 .home-slide-caption {
   opacity: 0;
   transform: translateY(8px);


### PR DESCRIPTION
## Summary

Vercel Speed Insights flagged desktop CLS 0.24 at P75 ("Needs Improvement"), driven by the homepage at **0.46** (kontakt's 0.54 is noise from 3 visits; project pages score 0).

Measured cause (production build, layout-shift observer): Swiper renders the hero strip server-side without slide widths; at JS init it sets them and the strip reflows in a single **0.4153** shift. Lighthouse missed it because it audits mobile emulation.

Fix: pre-init CSS sizes `.hero-swiper .swiper-slide` to mirror `slidesPerView`/`spaceBetween` per breakpoint, making Swiper's init geometrically a no-op. Loop-mode repositioning is transform-based and doesn't count toward CLS.

## Verification

- CLS measured **0.4153 → 0** on production build at 390px, 1024px, and 1440px viewports (buffered layout-shift observer, includes full-page scroll)
- `pnpm check` green

Field P75 should drift to "Great" as ~28-day data accumulates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)