### PR TITLE
Shrink consent separator dot to 4px

### DIFF
--- a/components/CookieBanner.tsx
+++ b/components/CookieBanner.tsx
@@ -91,7 +91,7 @@ export default function CookieBanner() {
                 </button>
                 <span
                   aria-hidden="true"
-                  className="mx-0.5 h-[7px] w-[7px] rounded-full bg-coral"
+                  className="mx-0.5 h-1 w-1 rounded-full bg-coral"
                 />
                 <button
                   onClick={() => choose(false)}


### PR DESCRIPTION
Follow-up to #27: the 7px separator dot read too heavy next to the 13px buttons — down to 4px, matching the typographic middle-dot weight in the design reference.

Verified on a production build; `pnpm build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)