### PR TITLE
Add engagement events: hero slider, map link, language toggle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ Project skills live in `.claude/skills/`; shared agent permissions in `.claude/s
 - Founder/internal traffic: open any page with `?kool=<name>` once per device → auto-opts-in and identifies as `team-<name>` with person property `internal: true`; the PostHog project's "Filter out internal and test users" filter (`internal` is not set) excludes those persons from insights — this is the only place `identify()` is allowed
 - Init lives in `instrumentation-client.ts`, gated on `NEXT_PUBLIC_POSTHOG_KEY` (no-op when unset, e.g. local dev)
 - Events proxied first-party through `/dot/*` (rewrites in `next.config.mjs`) to bypass ad blockers; `/dot` is excluded from the next-intl matcher in `proxy.ts` and `skipTrailingSlashRedirect` is required — keep all three in sync
-- Custom events go through `track()` in `lib/analytics.ts` (never import `posthog-js` in components directly); current events: `contact_email_click`, `instagram_click` (with `placement`)
+- Custom events go through `track()` in `lib/analytics.ts` (never import `posthog-js` in components directly); current events: `contact_email_click`, `instagram_click` (`placement`), `hero_slide_change`/`hero_project_click` (`project`), `map_address_click`, `language_switch` (`to`)
 - Vercel Analytics + Speed Insights remain in `app/[locale]/layout.tsx` alongside PostHog
 - `skipTrailingSlashRedirect` removes Next's sitewide slash normalization, so `proxy.ts` restores the trailing-slash 308 for page routes itself
 - The `kool-posthog` MCP server (`.mcp.json`) needs a PostHog *personal* API key (phx_…) exported as `KOOL_POSTHOG_PERSONAL_API_KEY` in the shell environment (not `.env.local` — MCP reads the process env)

--- a/components/AddressBlock.tsx
+++ b/components/AddressBlock.tsx
@@ -24,6 +24,7 @@ export default function AddressBlock() {
         href="https://maps.app.goo.gl/f3nJEyLJXxKStLvPA"
         target="_blank"
         rel="noopener noreferrer"
+        onClick={() => track('map_address_click')}
         className="flex min-h-11 items-center justify-between w-full font-[400] uppercase text-dark hover:opacity-70 transition-opacity text-[clamp(15px,1.5vw,20px)]"
       >
         <Distributed text={address} />

--- a/components/ImageStrip.tsx
+++ b/components/ImageStrip.tsx
@@ -18,6 +18,7 @@ import { A11y, Autoplay, Keyboard, Mousewheel } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css';
 import { Link } from '@/i18n/navigation';
+import { track } from '@/lib/analytics';
 import { localizeProject, projects } from '@/data/projects';
 import { curateHomepageProjects } from '@/data/homepage-projects';
 import { useReducedMotion } from '@/hooks/useReducedMotion';
@@ -86,6 +87,7 @@ function ProjectPane({
       className="group absolute inset-0 block outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-coral"
       aria-label={`${openProjectLabel}: ${project.title}, ${project.location}`}
       draggable={false}
+      onClick={() => track('hero_project_click', { project: project.slug })}
     >
       {/* bottom-px keeps the image 1px short of the viewport: Chrome
           excludes viewport-filling images from LCP candidates (treats them
@@ -212,6 +214,10 @@ export default function ImageStrip({ order }: { order: string[] }) {
   const handleManualChange = (swiper: SwiperInstance) => {
     const project = localizedProjects[swiper.realIndex];
     if (!project) return;
+
+    /* Only manual navigation reaches this handler (touch/keyboard/wheel),
+       never autoplay — so this measures deliberate hero engagement */
+    track('hero_slide_change', { project: project.slug });
 
     const nextStatus = t('projectStatus', {
       position: swiper.realIndex + 1,

--- a/components/LanguageToggle.tsx
+++ b/components/LanguageToggle.tsx
@@ -2,6 +2,7 @@
 
 import { useLocale } from 'next-intl';
 import { usePathname, useRouter } from '@/i18n/navigation';
+import { track } from '@/lib/analytics';
 
 export default function LanguageToggle() {
   const locale = useLocale();
@@ -10,6 +11,7 @@ export default function LanguageToggle() {
 
   const switchTo = (newLocale: 'pl' | 'en') => {
     if (newLocale !== locale) {
+      track('language_switch', { to: newLocale });
       router.replace(pathname, { locale: newLocale });
     }
   };


### PR DESCRIPTION
Adds the code half of the analytics expansion:

- `hero_slide_change` + `hero_project_click` (with `project` slug) — measures deliberate hero engagement; autoplay never fires the handler
- `map_address_click` — secondary contact-intent signal
- `language_switch` (with `to`) — sizes the EN audience

PostHog side (already live via API): scroll-depth insight, funnel-by-channel breakdown, Core Web Vitals p75, hourly lead alert on `contact_email_click`, and a Monday email digest to hello@koolstudio.pl.

`pnpm check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)