### PR TITLE
Lowercase brand to "kool studio" sitewide, expand sameAs profiles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# Kool Studio Website (kool-v2)
+# kool studio website (kool-v2)
 
-Portfolio website for Kool Studio, a Wroclaw-based interior architecture practice.
+Portfolio website for kool studio, a Wroclaw-based interior architecture practice.
 
 ## Quick Reference
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Kool Studio Website
+# kool studio Website
 
-Portfolio website for [Kool Studio](https://koolstudio.pl), a Wroclaw-based interior architecture practice.
+Portfolio website for [kool studio](https://koolstudio.pl), a Wroclaw-based interior architecture practice.
 
 ## Stack
 

--- a/app/[locale]/design-system/page.tsx
+++ b/app/[locale]/design-system/page.tsx
@@ -37,7 +37,7 @@ export default async function DesignSystemPage({
             Local design system
           </p>
           <h1 className="mt-4 uppercase text-dark font-[900] leading-[0.95] text-[36px] md:text-[82px]">
-            <span className="block">Kool Studio</span>
+            <span className="block">kool studio</span>
             <span className="block">visual language</span>
           </h1>
           <p className="mt-6 max-w-[760px] text-[16px] md:text-[20px] leading-[1.6] font-[300] text-dark">

--- a/app/[locale]/kontakt/KontaktPage.tsx
+++ b/app/[locale]/kontakt/KontaktPage.tsx
@@ -39,7 +39,7 @@ export default function KontaktPage() {
           >
             <LazyAutoplayVideo
               src="/videos/reel.mp4"
-              label="Kool Studio showreel"
+              label="kool studio showreel"
               className="w-[160px] h-[160px] md:w-[220px] md:h-[220px] object-cover"
             />
             <AddressBlock />

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -29,12 +29,12 @@ const isVercelDeployment = process.env.VERCEL === '1';
 export const metadata: Metadata = {
   metadataBase: new URL(BASE_URL),
   title: {
-    default: 'Kool Studio',
+    default: 'kool studio',
     template: '%s | kool studio',
   },
   keywords: 'architektura wnętrz, projektowanie wnętrz, Wrocław, Warszawa, interior design, architekt wnętrz, projekt wnętrz, meble na wymiar, design',
-  authors: [{ name: 'Kool Studio' }],
-  creator: 'Kool Studio',
+  authors: [{ name: 'kool studio' }],
+  creator: 'kool studio',
   robots: {
     index: true,
     follow: true,
@@ -79,13 +79,17 @@ export default async function LocaleLayout({
               '@context': 'https://schema.org',
               '@type': 'ProfessionalService',
               '@id': `${BASE_URL}/#studio`,
-              name: 'Kool Studio',
+              name: 'kool studio',
               description: tMeta('schemaDescription'),
               url: BASE_URL,
               email: 'hello@koolstudio.pl',
               image: `${BASE_URL}/images/studio/team.webp`,
               logo: `${BASE_URL}/logo.svg`,
-              sameAs: [INSTAGRAM_URL],
+              sameAs: [
+                INSTAGRAM_URL,
+                'https://www.facebook.com/its.kool.studio',
+                'https://maps.google.com/?cid=12276542814275745116',
+              ],
               founder: [
                 { '@type': 'Person', name: 'Ola Kilińska' },
                 { '@type': 'Person', name: 'Ola Leszczyńska' },

--- a/app/[locale]/not-found.tsx
+++ b/app/[locale]/not-found.tsx
@@ -36,7 +36,7 @@ export default function NotFound() {
         transition={{ delay: 1.6, duration: 0.6 }}
         className="mb-12"
       >
-        <Image src="/logo.svg" alt="Kool Studio" width={120} height={40} />
+        <Image src="/logo.svg" alt="kool studio" width={120} height={40} />
       </motion.div>
 
       {/* "oops!" letter by letter */}

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -45,7 +45,7 @@ export async function generateMetadata({
       type: 'website',
       locale: ogLocale(locale),
       alternateLocale: locale === 'en' ? 'pl_PL' : 'en_US',
-      siteName: 'Kool Studio',
+      siteName: 'kool studio',
       url: `${BASE_URL}/${locale}`,
       images: [socialImage],
     },

--- a/app/[locale]/projekty/[slug]/page.tsx
+++ b/app/[locale]/projekty/[slug]/page.tsx
@@ -79,7 +79,7 @@ export default async function ProjectDetailPage({
         creator: {
           '@type': 'ProfessionalService',
           '@id': `${BASE_URL}/#studio`,
-          name: 'Kool Studio',
+          name: 'kool studio',
           url: BASE_URL,
         },
         ...(project.meta?.collaboration

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -19,9 +19,9 @@ export function GET() {
       `- [${item.publication} — ${plMessages.studio.press.items[item.key].title}](${item.href})`
   );
 
-  const body = `# Kool Studio — Architektura Wnętrz / Interior Architecture & Design
+  const body = `# kool studio — Architektura Wnętrz / Interior Architecture & Design
 
-> Kool Studio is a Wrocław-based interior architecture practice led by architects Ola Kilińska and Ola Leszczyńska. The studio designs distinctive residential and commercial interiors, working from Wrocław on projects across Poland — including Warsaw, Łódź and Gdańsk. Project descriptions below are in Polish.
+> kool studio is a Wrocław-based interior architecture practice led by architects Ola Kilińska and Ola Leszczyńska. The studio designs distinctive residential and commercial interiors, working from Wrocław on projects across Poland — including Warsaw, Łódź and Gdańsk. Project descriptions below are in Polish.
 
 ## Pages
 - [Projekty / Projects](${BASE_URL}/pl/projekty): portfolio of residential and commercial interiors

--- a/components/FooterBanner.tsx
+++ b/components/FooterBanner.tsx
@@ -39,7 +39,7 @@ export default function FooterBanner({ showAddress = false, showMarquee = true }
           <div className="max-w-content mx-auto flex flex-col md:flex-row md:items-end md:justify-between gap-8 py-12">
             <LazyAutoplayVideo
               src="/videos/reel.mp4"
-              label="Kool Studio showreel"
+              label="kool studio showreel"
               className="w-[140px] h-[140px] md:w-[200px] md:h-[200px] object-cover"
             />
             <AddressBlock />

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -117,14 +117,14 @@ export default function Navbar() {
                 emits the preload without fetchpriority=high, leaving the logo
                 (the mobile LCP element) queued behind script downloads */}
             <span className="hidden md:block">
-              <Image src="/logo.svg" alt="Kool Studio" width={208} height={77} priority fetchPriority="high" />
+              <Image src="/logo.svg" alt="kool studio" width={208} height={77} priority fetchPriority="high" />
             </span>
             {/* Mobile: scale tracks scroll position */}
             <motion.span
               className="block md:hidden origin-top-left will-change-transform nav-logo-shrink"
               style={{ scale: logoScale }}
             >
-              <Image src="/logo.svg" alt="Kool Studio" width={208} height={77} priority fetchPriority="high" />
+              <Image src="/logo.svg" alt="kool studio" width={208} height={77} priority fetchPriority="high" />
             </motion.span>
           </Link>
 

--- a/components/ProjectContent.tsx
+++ b/components/ProjectContent.tsx
@@ -35,7 +35,7 @@ function PaddedImage({ src, small }: { src: string; small?: boolean }) {
     return (
       <ColumnImage
         src={src}
-        alt="Kool Studio project"
+        alt="kool studio project"
         aspect="aspect-[9/16]"
         width="w-[72%] md:w-[60%]"
         fit="contain"
@@ -48,7 +48,7 @@ function PaddedImage({ src, small }: { src: string; small?: boolean }) {
   return (
     <div className="w-full md:w-1/2 p-6 md:p-10 lg:p-14 xl:p-20">
       <div className="relative w-full h-full aspect-[3/4] md:aspect-auto">
-        <Image src={src} alt="Kool Studio project" fill className="object-contain" sizes="(max-width: 768px) 100vw, 40vw" />
+        <Image src={src} alt="kool studio project" fill className="object-contain" sizes="(max-width: 768px) 100vw, 40vw" />
       </div>
     </div>
   );
@@ -57,7 +57,7 @@ function PaddedImage({ src, small }: { src: string; small?: boolean }) {
 function FullImage({ src, portrait }: { src: string; portrait?: boolean }) {
   return (
     <div className={`w-full md:w-1/2 ${portrait ? 'aspect-[2/3]' : 'aspect-square'} relative`}>
-      <Image src={src} alt="Kool Studio project" fill className="object-cover" sizes="(max-width: 768px) 100vw, 50vw" quality={90} />
+      <Image src={src} alt="kool studio project" fill className="object-cover" sizes="(max-width: 768px) 100vw, 50vw" quality={90} />
     </div>
   );
 }
@@ -71,7 +71,7 @@ function ReelVideo({ src, aspect = 'aspect-[9/16]' }: { src: string; aspect?: st
         muted
         loop
         playsInline
-        aria-label="Kool Studio project video"
+        aria-label="kool studio project video"
         className={`mx-auto w-full max-w-[360px] ${aspect} object-cover`}
       />
     </div>
@@ -154,7 +154,7 @@ export default function ProjectContent({ images, description, descriptionBlocks,
     // Full-width row
     if (fullWidthSet.has(itemIdx) && current.kind === 'image') {
       rows.push(
-        <ParallaxImage key={`row-${rowIdx}`} src={current.src} alt="Kool Studio project" sizes="100vw" quality={90} />
+        <ParallaxImage key={`row-${rowIdx}`} src={current.src} alt="kool studio project" sizes="100vw" quality={90} />
       );
       itemIdx++;
       rowIdx++;

--- a/docs/ai-visibility-offsite.md
+++ b/docs/ai-visibility-offsite.md
@@ -1,6 +1,6 @@
 # Off-site AI visibility — action list
 
-Goal: when someone asks Claude, ChatGPT or Perplexity for "architekt wnętrz Wrocław" / "interior designer Warsaw", Kool Studio should be findable and citable. The on-site work (metadata, canonicals, crawlable nav/listing, JSON-LD, llms.txt) shipped in July 2026; everything below happens **outside the repo** and only the studio can do it (accounts, verification, outreach).
+Goal: when someone asks Claude, ChatGPT or Perplexity for "architekt wnętrz Wrocław" / "interior designer Warsaw", kool studio should be findable and citable. The on-site work (metadata, canonicals, crawlable nav/listing, JSON-LD, llms.txt) shipped in July 2026; everything below happens **outside the repo** and only the studio can do it (accounts, verification, outreach).
 
 How the engines actually source local businesses (mid-2026):
 
@@ -17,12 +17,12 @@ How the engines actually source local businesses (mid-2026):
 
 ## 2. Business listings (the "entity" layer)
 
-Keep NAP (name, address, phone) **byte-identical** everywhere: `Kool Studio, Zaporoska 83/15, 53-415 Wrocław` + hello@koolstudio.pl. Mention **both Wrocław (base) and Warsaw (service area)** in every description.
+Keep NAP (name, address, phone) **byte-identical** everywhere: `kool studio, Zaporoska 83/15, 53-415 Wrocław` + hello@koolstudio.pl (name lowercase — matches GBP and brand usage). Mention **both Wrocław (base) and Warsaw (service area)** in every description.
 
-- [ ] **Google Business Profile** — a "kool studio" place already exists on Google Maps (the pin the site's kontakt page links to). Claim/verify it at https://business.google.com, set category *Architekt wnętrz / Interior designer*, add services, photos per project, website link, and Warsaw as a service area. Then **ask past clients for reviews that name the service and city** ("projekt wnętrza mieszkania we Wrocławiu") — review text gets quoted in AI answers.
-- [ ] **Foursquare** — create/claim the listing at https://location.foursquare.com (or the Foursquare app), category Interior Designer / Design Studio, full NAP, description naming Wrocław + Warsaw, photos. *ChatGPT's primary local-name source; effect typically visible in 2–4 weeks.*
-- [ ] **Bing Places** — https://www.bingplaces.com (can import from Google Business Profile).
-- [ ] **Apple Business** — https://businessconnect.apple.com. Feeds Apple Maps, Siri and Apple Intelligence; most businesses still haven't claimed theirs, so it's cheap differentiation.
+- [x] **Google Business Profile** — claimed 2026-07-23 (place: https://maps.google.com/?cid=12276542814275745116, now in the site's `sameAs`). Still to do on the profile: category *Architekt wnętrz / Interior designer*, services, photos per project, website link (with UTM), Warsaw as a service area. Then **ask past clients for reviews that name the service and city** ("projekt wnętrza mieszkania we Wrocławiu") — review text gets quoted in AI answers.
+- [ ] **Foursquare** — the claim flow (https://business.foursquare.com/claim/?new_search=true; old location.foursquare.com link is dead) would not surface non-US places when tried 2026-07-23. Workaround: create the venue via the **Swarm app** (venue creation is global and free) with full NAP `kool studio, Zaporoska 83/15, Wrocław`, category Design Studio — *existence in Foursquare's Places data is what ChatGPT consumes; the paid claim (~$20) is only for management and can wait.* Retry the claim flow occasionally.
+- [x] **Bing Places** — created 2026-07-23 (Bing Webmaster Tools verified the same day). Public Bing Maps listing not yet visible — new listings take up to ~a week to publish; once live, capture the listing URL for `sameAs`.
+- [ ] **Apple Business** — https://businessconnect.apple.com. *Postponed (decision 2026-07-23).* Feeds Apple Maps, Siri and Apple Intelligence; cheap differentiation whenever picked back up.
 
 ## 3. Industry directories & portfolio platforms
 
@@ -38,7 +38,7 @@ Branded mentions in trusted media correlate ~3× stronger with AI-answer inclusi
 - [ ] For each completed project: professional photos + a short Polish press kit (story, city, metraż, materials, collaboration credits), pitched to **whitemad.pl, Label Magazine, Magazif, Domosfera, Czas na Wnętrze, Elle Decoration Polska**. Target 2–4 placements/year.
 - [ ] Submit the annual **Homebook Design** album entry.
 - [ ] For the strongest internationally photogenic project: **ArchDaily** (https://www.archdaily.com/submit-a-project — min. 15 photos at 2880px+, English narrative) and a **Dezeen** pitch. One acceptance = a permanent high-authority mention.
-- [ ] Ask journalists to name the studio as "Kool Studio" **with city context** in the article body.
+- [ ] Ask journalists to name the studio as "kool studio" **with city context** in the article body.
 
 ## 5. Social as an AI-crawlable surface
 
@@ -47,13 +47,13 @@ Branded mentions in trusted media correlate ~3× stronger with AI-answer inclusi
 
 ## 6. Later (after 2–3 press placements)
 
-- [ ] **Wikidata item** for Kool Studio (instance of: interior design firm; HQ: Wrocław; official website; references: press URLs). Feeds Google's Knowledge Graph and LLM entity layers; typical knowledge-panel lag is 2–6 months.
-- [ ] Add every claimed profile URL (Google Maps, Foursquare, Homebook, Archello, Architonic, Pinterest, Wikidata) to the site's JSON-LD `sameAs` array in `app/[locale]/layout.tsx` — currently it lists only Instagram.
+- [ ] **Wikidata item** for kool studio (instance of: interior design firm; HQ: Wrocław; official website; references: press URLs). Feeds Google's Knowledge Graph and LLM entity layers; typical knowledge-panel lag is 2–6 months.
+- [ ] Add every claimed profile URL (Foursquare, Homebook, Archello, Architonic, Pinterest, Wikidata, Bing Maps once published) to the site's JSON-LD `sameAs` array in `app/[locale]/layout.tsx` — Instagram + Facebook (https://www.facebook.com/its.kool.studio) + Google Maps added 2026-07-23.
 - [ ] Consider the deferred **FAQ section** (oferta/kontakt) with FAQPage schema — FAQ + rich schema showed ~44% higher AI-citation rates; the questions people ask assistants are "ile kosztuje projekt wnętrz we Wrocławiu", "czy pracujecie w Warszawie", "jak długo trwa projekt".
 
 ## 7. Measure (monthly, 15 min)
 
-- [ ] Ask Claude, ChatGPT and Perplexity (Polish + English): "architekt wnętrz Wrocław", "polecany projektant wnętrz Wrocław", "interior designer Warsaw Poland" — note whether Kool Studio appears and **which sources are cited**; put the next month's effort into whatever sources those are.
+- [ ] Ask Claude, ChatGPT and Perplexity (Polish + English): "architekt wnętrz Wrocław", "polecany projektant wnętrz Wrocław", "interior designer Warsaw Poland" — note whether kool studio appears and **which sources are cited**; put the next month's effort into whatever sources those are.
 - [ ] Check Bing Webmaster **AI Performance** and `site:koolstudio.pl` on Brave.
 
 ### Notes

--- a/docs/ai-visibility-offsite.pl.md
+++ b/docs/ai-visibility-offsite.pl.md
@@ -1,6 +1,6 @@
 # Widoczność w wyszukiwarkach AI — działania poza stroną
 
-Cel: gdy ktoś pyta Claude'a, ChatGPT albo Perplexity o „architekt wnętrz Wrocław" / „interior designer Warsaw", Kool Studio ma być znajdowalne i cytowalne. Prace na samej stronie (metadane, canonicale, indeksowalna nawigacja i lista projektów, JSON-LD, llms.txt) zostały wdrożone w lipcu 2026; wszystko poniżej dzieje się **poza repozytorium** i może to zrobić tylko studio (konta, weryfikacje, kontakt z mediami).
+Cel: gdy ktoś pyta Claude'a, ChatGPT albo Perplexity o „architekt wnętrz Wrocław" / „interior designer Warsaw", kool studio ma być znajdowalne i cytowalne. Prace na samej stronie (metadane, canonicale, indeksowalna nawigacja i lista projektów, JSON-LD, llms.txt) zostały wdrożone w lipcu 2026; wszystko poniżej dzieje się **poza repozytorium** i może to zrobić tylko studio (konta, weryfikacje, kontakt z mediami).
 
 Jak silniki AI naprawdę znajdują lokalne firmy (stan na połowę 2026):
 
@@ -17,12 +17,12 @@ Jak silniki AI naprawdę znajdują lokalne firmy (stan na połowę 2026):
 
 ## 2. Wizytówki firmowe (warstwa „encji")
 
-NAP (nazwa, adres, telefon) **identyczny co do znaku** wszędzie: `Kool Studio, Zaporoska 83/15, 53-415 Wrocław` + hello@koolstudio.pl. W każdym opisie wymieniaj **Wrocław (siedziba) i Warszawę (obszar działania)**.
+NAP (nazwa, adres, telefon) **identyczny co do znaku** wszędzie: `kool studio, Zaporoska 83/15, 53-415 Wrocław` + hello@koolstudio.pl. W każdym opisie wymieniaj **Wrocław (siedziba) i Warszawę (obszar działania)**.
 
-- [ ] **Profil Firmy w Google** — miejsce „kool studio" już istnieje w Google Maps (pinezka, do której linkuje strona kontaktu). Przejmij/zweryfikuj je na https://business.google.com, ustaw kategorię *Architekt wnętrz*, dodaj usługi, zdjęcia projektów, link do strony i Warszawę jako obszar obsługi. Potem **proś byłych klientów o opinie, które wymieniają usługę i miasto** („projekt wnętrza mieszkania we Wrocławiu") — treść opinii bywa cytowana w odpowiedziach AI.
-- [ ] **Foursquare** — załóż/przejmij wizytówkę na https://location.foursquare.com (albo w aplikacji), kategoria Interior Designer / Design Studio, pełny NAP, opis z Wrocławiem + Warszawą, zdjęcia. *Główne źródło lokalnych nazw dla ChatGPT; efekt zwykle widoczny w 2–4 tygodnie.*
-- [ ] **Bing Places** — https://www.bingplaces.com (można zaimportować z Profilu Firmy w Google).
-- [ ] **Apple Business** — https://businessconnect.apple.com. Zasila Apple Maps, Siri i Apple Intelligence; większość firm wciąż nie przejęła swoich wizytówek, więc to tania przewaga.
+- [x] **Profil Firmy w Google** — przejęty 23.07.2026 (wizytówka: https://maps.google.com/?cid=12276542814275745116, dodana do `sameAs` na stronie). Do zrobienia w profilu: kategoria *Architekt wnętrz*, usługi, zdjęcia projektów, link do strony (z UTM), Warszawa jako obszar obsługi. Potem **proś byłych klientów o opinie, które wymieniają usługę i miasto** („projekt wnętrza mieszkania we Wrocławiu") — treść opinii bywa cytowana w odpowiedziach AI.
+- [ ] **Foursquare** — formularz przejęcia (https://business.foursquare.com/claim/?new_search=true; stary link location.foursquare.com nie działa) nie znajdował miejsc spoza USA przy próbie 23.07.2026. Obejście: utwórz miejsce przez aplikację **Swarm** (dodawanie miejsc działa globalnie i jest darmowe) z pełnym NAP `kool studio, Zaporoska 83/15, Wrocław`, kategoria Design Studio — *dla ChatGPT liczy się samo istnienie miejsca w danych Foursquare; płatne przejęcie (~20 USD) służy tylko do zarządzania i może poczekać.* Co jakiś czas ponów próbę przejęcia.
+- [x] **Bing Places** — założone 23.07.2026 (Bing Webmaster Tools zweryfikowany tego samego dnia). Publiczna wizytówka w Bing Maps jeszcze niewidoczna — nowe wpisy publikują się do ok. tygodnia; gdy się pojawi, zapisz jej adres do `sameAs`.
+- [ ] **Apple Business** — https://businessconnect.apple.com. *Odłożone (decyzja 23.07.2026).* Zasila Apple Maps, Siri i Apple Intelligence; tania przewaga, gdy temat wróci.
 
 ## 3. Katalogi branżowe i platformy portfolio
 
@@ -38,7 +38,7 @@ Wzmianki o marce w zaufanych mediach korelują z obecnością w odpowiedziach AI
 - [ ] Dla każdego ukończonego projektu: profesjonalne zdjęcia + krótki polski press kit (historia, miasto, metraż, materiały, współprace), wysyłany do **whitemad.pl, Label Magazine, Magazif, Domosfera, Czas na Wnętrze, Elle Decoration Polska**. Cel: 2–4 publikacje rocznie.
 - [ ] Zgłoszenie do dorocznego albumu **Homebook Design**.
 - [ ] Najmocniejszy, najlepiej sfotografowany projekt: **ArchDaily** (https://www.archdaily.com/submit-a-project — min. 15 zdjęć 2880px+, narracja po angielsku) i pitch do **Dezeen**. Jedna akceptacja = trwała wzmianka o wysokim autorytecie.
-- [ ] Proś dziennikarzy, by w treści artykułu padała nazwa „Kool Studio" **wraz z miastem**.
+- [ ] Proś dziennikarzy, by w treści artykułu padała nazwa „kool studio" **wraz z miastem**.
 
 ## 5. Social media jako powierzchnia dla crawlerów AI
 
@@ -47,13 +47,13 @@ Wzmianki o marce w zaufanych mediach korelują z obecnością w odpowiedziach AI
 
 ## 6. Później (po 2–3 publikacjach prasowych)
 
-- [ ] **Rekord w Wikidata** dla Kool Studio (instancja: pracownia projektowania wnętrz; siedziba: Wrocław; oficjalna strona; źródła: adresy publikacji prasowych). Zasila Google Knowledge Graph i warstwy encji LLM-ów; typowe opóźnienie panelu wiedzy to 2–6 miesięcy.
-- [ ] Dodaj adres każdego przejętego profilu (Google Maps, Foursquare, Homebook, Archello, Architonic, Pinterest, Wikidata) do tablicy `sameAs` w JSON-LD strony w `app/[locale]/layout.tsx` — dziś jest tam tylko Instagram.
+- [ ] **Rekord w Wikidata** dla kool studio (instancja: pracownia projektowania wnętrz; siedziba: Wrocław; oficjalna strona; źródła: adresy publikacji prasowych). Zasila Google Knowledge Graph i warstwy encji LLM-ów; typowe opóźnienie panelu wiedzy to 2–6 miesięcy.
+- [ ] Dodaj adres każdego przejętego profilu (Foursquare, Homebook, Archello, Architonic, Pinterest, Wikidata, Bing Maps po publikacji) do tablicy `sameAs` w JSON-LD strony w `app/[locale]/layout.tsx` — Instagram + Facebook (https://www.facebook.com/its.kool.studio) + Google Maps dodane 23.07.2026.
 - [ ] Rozważ odłożoną na później **sekcję FAQ** (oferta/kontakt) ze schematem FAQPage — FAQ + rozbudowany schema dawały ~44% więcej cytowań AI; ludzie pytają asystentów o „ile kosztuje projekt wnętrz we Wrocławiu", „czy pracujecie w Warszawie", „jak długo trwa projekt".
 
 ## 7. Pomiar (co miesiąc, 15 minut)
 
-- [ ] Zapytaj Claude'a, ChatGPT i Perplexity (po polsku i angielsku): „architekt wnętrz Wrocław", „polecany projektant wnętrz Wrocław", „interior designer Warsaw Poland" — zanotuj, czy Kool Studio się pojawia i **jakie źródła są cytowane**; wysiłek kolejnego miesiąca kieruj w te źródła.
+- [ ] Zapytaj Claude'a, ChatGPT i Perplexity (po polsku i angielsku): „architekt wnętrz Wrocław", „polecany projektant wnętrz Wrocław", „interior designer Warsaw Poland" — zanotuj, czy kool studio się pojawia i **jakie źródła są cytowane**; wysiłek kolejnego miesiąca kieruj w te źródła.
 - [ ] Sprawdź raport **AI Performance** w Bing Webmaster i `site:koolstudio.pl` w Brave.
 
 ### Uwagi

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -51,7 +51,7 @@ export async function pageMetadata(locale: string, key: MetaPageKey): Promise<Me
       title: `${title} | kool studio`,
       description,
       type: 'website',
-      siteName: 'Kool Studio',
+      siteName: 'kool studio',
       locale: ogLocale(locale),
       alternateLocale: locale === 'en' ? 'pl_PL' : 'en_US',
       url: `${BASE_URL}/${locale}${path}`,

--- a/messages/en.json
+++ b/messages/en.json
@@ -21,34 +21,34 @@
     "schemaDescription": "Wrocław-based interior architecture practice specializing in residential and commercial interiors, custom furniture, lighting design, and visual identity. Projects across Poland, including Warsaw.",
     "home": {
       "title": "kool studio | interior architecture wrocław, poland",
-      "description": "Kool Studio — a Wrocław-based interior architecture practice. We design original residential and commercial interiors across Poland. Custom furniture, lighting, visual identity.",
+      "description": "kool studio — a Wrocław-based interior architecture practice. We design original residential and commercial interiors across Poland. Custom furniture, lighting, visual identity.",
       "ogDescription": "Original interiors that stay for longer. We design residential and commercial spaces in Wrocław, Warsaw and across Poland.",
-      "ogImageAlt": "Walecznych apartment interior designed by Kool Studio"
+      "ogImageAlt": "Walecznych apartment interior designed by kool studio"
     },
     "projekty": {
       "title": "projects — interior design portfolio",
-      "description": "Kool Studio portfolio — apartments, houses, restaurants, hotels and commercial interiors in Wrocław, Warsaw and across Poland.",
-      "ogImageAlt": "Dehesa delicatessen interior designed by Kool Studio"
+      "description": "kool studio portfolio — apartments, houses, restaurants, hotels and commercial interiors in Wrocław, Warsaw and across Poland.",
+      "ogImageAlt": "Dehesa delicatessen interior designed by kool studio"
     },
     "studio": {
       "title": "studio — about us",
-      "description": "Kool Studio is led by architects Ola Kilińska and Ola Leszczyńska. The Wrocław-based practice designs residential and commercial interiors across Poland.",
-      "ogImageAlt": "Ola Kilińska and Ola Leszczyńska in the Kool Studio workspace"
+      "description": "kool studio is led by architects Ola Kilińska and Ola Leszczyńska. The Wrocław-based practice designs residential and commercial interiors across Poland.",
+      "ogImageAlt": "Ola Kilińska and Ola Leszczyńska in the kool studio workspace"
     },
     "oferta": {
       "title": "services — interior design",
       "description": "Comprehensive interior design for commercial and residential spaces: concept, construction documentation, author's supervision, custom furniture, branding. Wrocław and all of Poland.",
-      "ogImageAlt": "Restaurant interior designed by Kool Studio"
+      "ogImageAlt": "Restaurant interior designed by kool studio"
     },
     "kontakt": {
       "title": "contact",
-      "description": "Get in touch with Kool Studio — an interior architecture practice from Wrocław, Poland. Studio: Zaporoska 83/15, 53-415 Wrocław. Email: hello@koolstudio.pl.",
-      "ogImageAlt": "Material and color palette in the Kool Studio workspace"
+      "description": "Get in touch with kool studio — an interior architecture practice from Wrocław, Poland. Studio: Zaporoska 83/15, 53-415 Wrocław. Email: hello@koolstudio.pl.",
+      "ogImageAlt": "Material and color palette in the kool studio workspace"
     },
     "polityka-prywatnosci": {
       "title": "Privacy policy",
-      "description": "How Kool Studio handles personal data and cookies.",
-      "ogImageAlt": "Material and color palette in the Kool Studio workspace"
+      "description": "How kool studio handles personal data and cookies.",
+      "ogImageAlt": "Material and color palette in the kool studio workspace"
     }
   },
   "projects": {
@@ -79,8 +79,8 @@
     "title": "Studio",
     "manifesto": "WE ARE KOOL AND WE DESIGN KOOL THINGS!",
     "intro": "A Wrocław-based design studio founded by the dynamic architect duo Ola Kilińska and Ola Leszczyńska. We create distinctive interiors and commercial spaces that are as functional as they are inspiring. Combining disciplines from interior design and strategy to product development and visual identity, we create concepts that unite practicality with beauty. Our spaces do more than work – they resonate, evoke emotion, and leave a lasting impression.",
-    "heroImageAlt": "Ola Kilińska and Ola Leszczyńska in the Kool Studio workspace",
-    "detailImageAlt": "Materials and samples in the Kool Studio workspace",
+    "heroImageAlt": "Ola Kilińska and Ola Leszczyńska in the kool studio workspace",
+    "detailImageAlt": "Materials and samples in the kool studio workspace",
     "pressHeading": "Featured in",
     "press": {
       "items": {
@@ -173,7 +173,7 @@
   },
   "privacy": {
     "title": "Privacy policy",
-    "intro": "The controller of your personal data is Kool Studio, Zaporoska 83/15, Wrocław, Poland. For any data-related matters, write to hello@koolstudio.pl.",
+    "intro": "The controller of your personal data is kool studio, Zaporoska 83/15, Wrocław, Poland. For any data-related matters, write to hello@koolstudio.pl.",
     "contactLabel": "Email contact",
     "contactBody": "When you write to hello@koolstudio.pl, we process your email address and the content of your message solely to reply and discuss a potential collaboration. We keep correspondence for as long as the matter requires.",
     "analyticsLabel": "Visit statistics",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -21,34 +21,34 @@
     "schemaDescription": "Wrocławska pracownia architektury wnętrz projektująca wnętrza mieszkalne i komercyjne, autorskie meble, oświetlenie i identyfikację wizualną. Projekty w całej Polsce, m.in. w Warszawie.",
     "home": {
       "title": "kool studio | architektura wnętrz wrocław",
-      "description": "Kool Studio — wrocławska pracownia architektury wnętrz. Projektujemy autorskie wnętrza mieszkalne i komercyjne z dbałością o detal. Meble, lampy, identyfikacja wizualna.",
+      "description": "kool studio — wrocławska pracownia architektury wnętrz. Projektujemy autorskie wnętrza mieszkalne i komercyjne z dbałością o detal. Meble, lampy, identyfikacja wizualna.",
       "ogDescription": "Autorskie wnętrza, które zostają na dłużej. Projektowanie przestrzeni mieszkalnych i komercyjnych.",
-      "ogImageAlt": "Wnętrze mieszkania przy ulicy Walecznych zaprojektowane przez Kool Studio"
+      "ogImageAlt": "Wnętrze mieszkania przy ulicy Walecznych zaprojektowane przez kool studio"
     },
     "projekty": {
       "title": "projekty — portfolio wnętrz",
-      "description": "Portfolio projektów Kool Studio — mieszkania, domy, restauracje, hotele i wnętrza komercyjne we Wrocławiu, Warszawie i całej Polsce.",
-      "ogImageAlt": "Wnętrze delikatesów Dehesa zaprojektowane przez Kool Studio"
+      "description": "Portfolio projektów kool studio — mieszkania, domy, restauracje, hotele i wnętrza komercyjne we Wrocławiu, Warszawie i całej Polsce.",
+      "ogImageAlt": "Wnętrze delikatesów Dehesa zaprojektowane przez kool studio"
     },
     "studio": {
       "title": "studio — o nas",
-      "description": "Kool Studio tworzą architektki Ola Kilińska i Ola Leszczyńska. Wrocławska pracownia projektuje wnętrza mieszkalne i komercyjne w całej Polsce.",
-      "ogImageAlt": "Ola Kilińska i Ola Leszczyńska w pracowni Kool Studio"
+      "description": "kool studio tworzą architektki Ola Kilińska i Ola Leszczyńska. Wrocławska pracownia projektuje wnętrza mieszkalne i komercyjne w całej Polsce.",
+      "ogImageAlt": "Ola Kilińska i Ola Leszczyńska w pracowni kool studio"
     },
     "oferta": {
       "title": "oferta — projektowanie wnętrz",
       "description": "Kompleksowe projektowanie wnętrz komercyjnych i mieszkalnych: koncepcja, dokumentacja wykonawcza, nadzór autorski, meble na wymiar, branding. Wrocław i cała Polska.",
-      "ogImageAlt": "Wnętrze restauracji zaprojektowane przez Kool Studio"
+      "ogImageAlt": "Wnętrze restauracji zaprojektowane przez kool studio"
     },
     "kontakt": {
       "title": "kontakt",
-      "description": "Skontaktuj się z Kool Studio — pracownią architektury wnętrz z Wrocławia. Studio: Zaporoska 83/15, 53-415 Wrocław. E-mail: hello@koolstudio.pl.",
-      "ogImageAlt": "Paleta materiałów i kolorów w pracowni Kool Studio"
+      "description": "Skontaktuj się z kool studio — pracownią architektury wnętrz z Wrocławia. Studio: Zaporoska 83/15, 53-415 Wrocław. E-mail: hello@koolstudio.pl.",
+      "ogImageAlt": "Paleta materiałów i kolorów w pracowni kool studio"
     },
     "polityka-prywatnosci": {
       "title": "Polityka prywatności",
-      "description": "Zasady przetwarzania danych osobowych i plików cookie na stronie Kool Studio.",
-      "ogImageAlt": "Paleta materiałów i kolorów w pracowni Kool Studio"
+      "description": "Zasady przetwarzania danych osobowych i plików cookie na stronie kool studio.",
+      "ogImageAlt": "Paleta materiałów i kolorów w pracowni kool studio"
     }
   },
   "projects": {
@@ -79,8 +79,8 @@
     "title": "Studio",
     "manifesto": "WE ARE KOOL AND WE DESIGN KOOL THINGS!",
     "intro": "Wrocławskie studio projektowe założone przez dynamiczny duet architektek – Olę Kilińską i Olę Leszczyńską. Tworzymy wyjątkowe wnętrza i przestrzenie komercyjne, które są równie funkcjonalne, co inspirujące. Łącząc różne dyscypliny, od projektowania wnętrz i strategii, po rozwój produktu i identyfikację wizualną, tworzymy koncepcje, które włączą praktyczność z pięknem. Nasze przestrzenie nie tylko działają – one rezonują, wywołują emocje i pozostawiają trwałe wrażenie.",
-    "heroImageAlt": "Ola Kilińska i Ola Leszczyńska w pracowni Kool Studio",
-    "detailImageAlt": "Materiały i próbki w pracowni Kool Studio",
+    "heroImageAlt": "Ola Kilińska i Ola Leszczyńska w pracowni kool studio",
+    "detailImageAlt": "Materiały i próbki w pracowni kool studio",
     "pressHeading": "Napisali o nas",
     "press": {
       "items": {
@@ -173,7 +173,7 @@
   },
   "privacy": {
     "title": "Polityka prywatności",
-    "intro": "Administratorem Twoich danych osobowych jest Kool Studio, ul. Zaporoska 83/15, Wrocław. W sprawach dotyczących danych osobowych napisz na hello@koolstudio.pl.",
+    "intro": "Administratorem Twoich danych osobowych jest kool studio, ul. Zaporoska 83/15, Wrocław. W sprawach dotyczących danych osobowych napisz na hello@koolstudio.pl.",
     "contactLabel": "Kontakt e-mail",
     "contactBody": "Gdy piszesz na hello@koolstudio.pl, przetwarzamy Twój adres e-mail i treść wiadomości wyłącznie po to, aby odpowiedzieć i poprowadzić rozmowę o współpracy. Korespondencję przechowujemy tak długo, jak wymaga tego prowadzona sprawa.",
     "analyticsLabel": "Statystyki odwiedzin",


### PR DESCRIPTION
## Summary

- Replaces every user-facing "Kool Studio" with the lowercase brand form **"kool studio"** — page titles, meta descriptions, OG `siteName`, image alt texts, JSON-LD entity/publisher names, `llms.txt`, both message catalogs, README and docs. This makes the site's NAP byte-identical with the freshly claimed Google Business Profile (which uses lowercase).
- Expands the JSON-LD `sameAs` array from Instagram-only to Instagram + the studio's Facebook page + the Google Business Profile place (stable `?cid=` URL resolved from the existing map short-link).
- Updates `docs/ai-visibility-offsite.md` and its Polish twin: GBP + Bing Places/Webmaster Tools marked done (2026-07-23), Apple Business postponed, Foursquare's dead claim link replaced with the current flow plus a Swarm-based workaround for the US-only claim search.

Deliberate exception: the PostHog dashboard reference in CLAUDE.md stays "Kool Studio — witryna" (the dashboard's literal name); `docs/superpowers/` specs/plans are historical records and untouched.

## Test plan

- `pnpm check` passes: vitest + node:test suites, typecheck, ESLint, pl/en i18n key parity, production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)