### PR TITLE
deps: scope Dependabot group to minor/patch, hold major TS & ESLint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,24 @@ updates:
     commit-message:
       prefix: ci
 
-  # Batch npm updates into a single weekly PR to keep the noise down
+  # Batch only safe minor/patch bumps into one weekly PR (auto-mergeable).
+  # Major bumps come as individual PRs for manual review, so one breaking
+  # change never blocks the safe updates the way a single all-in group does.
   - package-ecosystem: npm
     directory: "/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
     groups:
-      all-dependencies:
+      minor-and-patch:
+        update-types: [minor, patch]
         patterns: ["*"]
+    ignore:
+      # Coordinated toolchain migrations — bump these deliberately by hand,
+      # not via Dependabot (TypeScript 7 drops the ES5 target the config uses).
+      - dependency-name: typescript
+        update-types: [version-update:semver-major]
+      - dependency-name: eslint
+        update-types: [version-update:semver-major]
     commit-message:
       prefix: deps


### PR DESCRIPTION
## Why
On first activation, Dependabot's all-in npm group (PR #41) batched **breaking majors** — TypeScript 7 (drops the `target: ES5` our tsconfig uses) and ESLint 10 — with everything else. One bad major failed the whole grouped PR **and** its Vercel preview deploy. CI + branch protection correctly blocked it, but it's noise.

## Change
- Group only **minor/patch** npm bumps into the weekly PR (safe, auto-mergeable).
- Majors now come as **individual** PRs for manual review, so a breaking change never blocks the safe updates.
- **Ignore** major `typescript` and `eslint` bumps outright — coordinated migrations to do by hand.

No app code changes. Production `main` was never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)