### PR TITLE
Three scroll/blur touches: progressive blur, oferta spine, footer dot

### DIFF
--- a/app/[locale]/studio/StudioPage.tsx
+++ b/app/[locale]/studio/StudioPage.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { useTranslations } from 'next-intl';
 import { pressItems } from '@/data/press';
 import FooterBanner from '@/components/FooterBanner';
+import MarqueeEdges from '@/components/MarqueeEdges';
 import Navbar from '@/components/Navbar';
 import ProjectHero from '@/components/ProjectHero';
 import Reveal from '@/components/Reveal';
@@ -43,7 +44,7 @@ export default function StudioPage() {
       <Navbar />
       <main>
         <div className="relative z-10 bg-beige">
-          <section className="overflow-hidden whitespace-nowrap pt-16 pb-8 md:pt-24 md:pb-12">
+          <section className="relative overflow-hidden whitespace-nowrap pt-16 pb-8 md:pt-24 md:pb-12">
             <h1 className="animate-marquee inline-block motion-reduce:animate-none">
               <span
                 className="font-[400] uppercase text-coral leading-tight mx-8 md:mx-16"
@@ -62,6 +63,7 @@ export default function StudioPage() {
                 </span>
               ))}
             </h1>
+            <MarqueeEdges />
           </section>
 
           <section className="px-5 pt-10 pb-20 md:px-10 md:pt-14 md:pb-28 lg:px-[68px] lg:pt-20 lg:pb-36">

--- a/components/FooterBanner.tsx
+++ b/components/FooterBanner.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from 'next-intl';
 import AddressBlock from './AddressBlock';
 import FooterBar from './FooterBar';
 import LazyAutoplayVideo from './LazyAutoplayVideo';
+import MarqueeEdges from './MarqueeEdges';
 
 interface FooterBannerProps {
   showAddress?: boolean;
@@ -18,7 +19,7 @@ export default function FooterBanner({ showAddress = false, showMarquee = true }
     <footer className="pb-[calc(61px+env(safe-area-inset-bottom))] md:pb-[calc(43px+env(safe-area-inset-bottom))]">
       {/* Marquee */}
       {showMarquee && (
-        <div className="overflow-hidden whitespace-nowrap pt-8 md:pt-12 pb-2">
+        <div className="relative overflow-hidden whitespace-nowrap pt-8 md:pt-12 pb-2">
           <div className="animate-marquee inline-block">
             {Array.from({ length: 4 }).map((_, i) => (
               <span
@@ -30,6 +31,7 @@ export default function FooterBanner({ showAddress = false, showMarquee = true }
               </span>
             ))}
           </div>
+          <MarqueeEdges />
         </div>
       )}
 

--- a/components/FooterBar.tsx
+++ b/components/FooterBar.tsx
@@ -6,6 +6,7 @@ import { openCookieSettings, track } from '@/lib/analytics';
 import CookieBanner from './CookieBanner';
 import FooterHairline from './FooterHairline';
 import LanguageToggle from './LanguageToggle';
+import ScrollDot from './ScrollDot';
 
 export default function FooterBar() {
   const t = useTranslations('cookies');
@@ -19,6 +20,12 @@ export default function FooterBar() {
           bend where the dot strikes it. */}
       <div data-footer-line className="relative h-px w-full">
         <FooterHairline />
+        {/* Reading progress rides the same line, on every page. Absolutely
+            positioned and painted after the hairline: it adds nothing to this
+            box's rect, which the idle drop measures, and it sits above the
+            coral half-pixel but still under the nav (z-50), so the falling
+            dot passes in front of it. */}
+        <ScrollDot />
       </div>
       <div className="flex items-center justify-between px-3 py-2 md:px-5">
         <a

--- a/components/ManifestoSection.tsx
+++ b/components/ManifestoSection.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from 'next-intl';
 import ColumnImage from '@/components/ColumnImage';
+import MarqueeEdges from '@/components/MarqueeEdges';
 import RevealHeading from '@/components/RevealHeading';
 
 function ManifestoText({ heading, text }: { heading: string; text: string }) {
@@ -53,7 +54,7 @@ export default function ManifestoSection() {
       </section>
 
       {/* Marquee */}
-      <div className="overflow-hidden whitespace-nowrap py-16 md:py-24">
+      <div className="relative overflow-hidden whitespace-nowrap py-16 md:py-24">
         <div className="animate-marquee inline-block">
           {Array.from({ length: 4 }).map((_, i) => (
             <span
@@ -65,6 +66,7 @@ export default function ManifestoSection() {
             </span>
           ))}
         </div>
+        <MarqueeEdges />
       </div>
 
       {/* Section 2: image left, text right — project-page 50/50 row */}

--- a/components/MarqueeEdges.tsx
+++ b/components/MarqueeEdges.tsx
@@ -1,0 +1,18 @@
+import ProgressiveBlur from './ProgressiveBlur';
+
+/* The coral marquees run edge to edge, so without this the text is guillotined
+   mid-letter at both sides. These dissolve it into the page instead.
+
+   Tint only, deliberately: a backdrop-filter over text that never stops moving
+   would repaint the whole band every frame, and over a flat beige background a
+   gradient is indistinguishable from a blur.
+
+   Expects a `relative overflow-hidden` marquee wrapper. */
+export default function MarqueeEdges() {
+  return (
+    <>
+      <ProgressiveBlur position="left" size="14%" blur={0} tint="var(--color-beige)" />
+      <ProgressiveBlur position="right" size="14%" blur={0} tint="var(--color-beige)" />
+    </>
+  );
+}

--- a/components/ProgressiveBlur.tsx
+++ b/components/ProgressiveBlur.tsx
@@ -1,0 +1,95 @@
+type Edge = 'top' | 'bottom' | 'left' | 'right';
+
+/* The effect always fades away from the named edge. */
+const FADE_DIRECTION: Record<Edge, string> = {
+  top: 'to bottom',
+  bottom: 'to top',
+  left: 'to right',
+  right: 'to left',
+};
+
+const EDGE_BOX: Record<Edge, string> = {
+  top: 'inset-x-0 top-0',
+  bottom: 'inset-x-0 bottom-0',
+  left: 'inset-y-0 left-0',
+  right: 'inset-y-0 right-0',
+};
+
+/* Fraction of each layer's reach that stays fully opaque before its mask
+   starts ramping. Without it the outermost pixel row is already partially
+   unmasked on every layer and the edge never reaches full strength. */
+const PLATEAU = 0.3;
+
+interface ProgressiveBlurProps {
+  /** Which edge the effect hugs; it fades inward from there. */
+  position?: Edge;
+  /** Depth of the effect — height for top/bottom, width for left/right. */
+  size?: string;
+  /** Number of stacked blur layers. Ignored when `blur` is 0. */
+  layers?: number;
+  /** Base blur radius in px; layer i uses blur × 2^i. 0 = tint only. */
+  blur?: number;
+  /** Optional colour faded in over the blur (same direction as the mask). */
+  tint?: string;
+  className?: string;
+}
+
+/* A progressive blur edge: a blur *ramp* rather than a band with a seam.
+   One backdrop-filter can only be uniform, so N layers are stacked, each with
+   twice the radius of the one below it and each masked to a shorter reach
+   from the edge. Every layer's filter sees the layers behind it as part of its
+   backdrop, so the radii accumulate where the layers overlap — hardest against
+   the edge, thinning to nothing at `size`, with no step anywhere in between.
+
+   Positioned absolutely; it expects a positioned ancestor sized to the area
+   that should be affected (wrap it in a `fixed` box to pin it to the viewport).
+   Decorative only — hidden from AT and transparent to pointer events. */
+export default function ProgressiveBlur({
+  position = 'bottom',
+  size = '120px',
+  layers = 4,
+  blur = 2,
+  tint,
+  className = '',
+}: ProgressiveBlurProps) {
+  const direction = FADE_DIRECTION[position];
+  const horizontal = position === 'left' || position === 'right';
+  const layerCount = blur > 0 ? Math.max(1, Math.round(layers)) : 0;
+
+  return (
+    <div
+      aria-hidden="true"
+      className={`pointer-events-none absolute ${EDGE_BOX[position]} ${className}`}
+      style={horizontal ? { width: size } : { height: size }}
+    >
+      {Array.from({ length: layerCount }, (_, i) => {
+        const radius = blur * 2 ** i;
+        const reach = ((layerCount - i) / layerCount) * 100;
+        const mask =
+          `linear-gradient(${direction}, rgb(0 0 0) 0%,` +
+          ` rgb(0 0 0) ${(reach * PLATEAU).toFixed(2)}%,` +
+          ` rgb(0 0 0 / 0) ${reach.toFixed(2)}%)`;
+
+        return (
+          <div
+            key={i}
+            className="absolute inset-0"
+            style={{
+              backdropFilter: `blur(${radius}px)`,
+              WebkitBackdropFilter: `blur(${radius}px)`,
+              maskImage: mask,
+              WebkitMaskImage: mask,
+            }}
+          />
+        );
+      })}
+
+      {tint && (
+        <div
+          className="absolute inset-0"
+          style={{ backgroundImage: `linear-gradient(${direction}, ${tint}, transparent)` }}
+        />
+      )}
+    </div>
+  );
+}

--- a/components/ProjectHero.tsx
+++ b/components/ProjectHero.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import ProgressiveBlur from './ProgressiveBlur';
 
 interface ProjectHeroProps {
   src: string;
@@ -21,6 +22,23 @@ export default function ProjectHero({ src, alt, imageClassName = '' }: ProjectHe
           quality={90}
           priority
         />
+      </div>
+      {/* Nav legibility. The coral logo, links and dot sit on whatever photo
+          the page happens to open with, so the header band gets a blur ramp
+          and a whisper of beige — enough to hold the accent colour off any
+          highlight, not enough to read as a grey bar. Pinned in its own fixed
+          box (Tailwind's .absolute would win over a .fixed passed through
+          className regardless of order).
+
+          Deliberately just above the photo rather than above the page: at a
+          header-level z-index this turns into a frosted bar that softens every
+          image scrolling under it, and on a portfolio the photography has to
+          stay crisp. Here it only ever blurs the fixed hero. */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none fixed inset-x-0 top-0 z-[5] h-[calc(var(--nav-header-bottom)+40px)]"
+      >
+        <ProgressiveBlur position="top" size="100%" layers={4} blur={1.5} tint="rgb(229 221 208 / 0.2)" />
       </div>
       <div
         aria-hidden="true"

--- a/components/ScrollDot.tsx
+++ b/components/ScrollDot.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { motion, useScroll, useSpring, useTransform } from 'framer-motion';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+
+/* Stiffer than a progress bar's spring would need to be: this value is read as
+   a position along the full width of the viewport rather than as a scale, so
+   the same normalised lag that is invisible on a growing rule shows up here as
+   the dot trailing the scroll by tens of pixels. restDelta is ~0.3px on a
+   1400px line. */
+const TRAVEL_SPRING = { stiffness: 240, damping: 36, restDelta: 0.0002 } as const;
+
+/* The brand dot, not a circle — dot.svg is 36:35, the ratio the navbar renders
+   it at, and it is masked rather than drawn so the silhouette is the same
+   asymmetric mark in both places. 7px is the smallest size that still reads as
+   that mark against a half-pixel hairline; below it the shape collapses into a
+   speck. */
+const DOT_WIDTH = 7;
+const DOT_HEIGHT = (DOT_WIDTH * 35) / 36;
+
+/* FooterHairline paints its half pixel of coral across [0, 0.5] of the h-px
+   box it sits in (its viewBox is offset so one unit is one CSS pixel and the
+   rect starts at the box's top edge), so the line's centre is a quarter pixel
+   down — not the half pixel `top-1/2` would give. */
+const LINE_CENTER = 0.25;
+
+const DOT_MASK = {
+  maskImage: 'url(/dot.svg)',
+  maskSize: 'contain',
+  maskRepeat: 'no-repeat',
+  WebkitMaskImage: 'url(/dot.svg)',
+  WebkitMaskSize: 'contain',
+  WebkitMaskRepeat: 'no-repeat',
+} as const;
+
+/* The dot travels `width - DOT_WIDTH`, so that it is flush inside both ends
+   rather than hanging half off them — and it has to do that without measuring
+   anything, because [data-footer-line] is the idle drop's landing target and
+   nothing here may read or perturb its layout.
+   A percentage translate resolves against the element's OWN width, which is
+   the wrong 100%. So the travel is handed to a zero-height track that is
+   exactly `100% - DOT_WIDTH` wide: translating that track by 100% of itself
+   moves the dot pinned at its left edge by exactly the distance wanted, at any
+   viewport width, with no ResizeObserver and no layout read. */
+function Rider() {
+  const { scrollYProgress } = useScroll();
+  const progress = useSpring(scrollYProgress, TRAVEL_SPRING);
+  const x = useTransform(progress, [0, 1], ['0%', '100%']);
+
+  return (
+    <motion.div
+      aria-hidden="true"
+      className="pointer-events-none absolute left-0 top-0 z-10 h-0"
+      style={{ width: `calc(100% - ${DOT_WIDTH}px)`, x }}
+    >
+      <div
+        className="absolute left-0 bg-coral"
+        style={{
+          width: `${DOT_WIDTH}px`,
+          height: `${DOT_HEIGHT}px`,
+          top: `${LINE_CENTER - DOT_HEIGHT / 2}px`,
+          ...DOT_MASK,
+        }}
+      />
+    </motion.div>
+  );
+}
+
+/* Reduced motion gets nothing at all — the branch is above the hooks, so the
+   scroll subscription is never mounted. A parked dot has no meaning: unlike a
+   spine or a rule it has no resting state to fall back to, and a coral speck
+   sitting at the left end of the footer line reads as a stray design element
+   rather than as progress. */
+export default function ScrollDot() {
+  const reduceMotion = useReducedMotion();
+
+  if (reduceMotion) return null;
+
+  return <Rider />;
+}

--- a/components/ScrollSpine.tsx
+++ b/components/ScrollSpine.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useRef } from 'react';
+import { motion, useScroll, useSpring } from 'framer-motion';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+
+/* Enough to take the edge off wheel/trackpad steps without the line visibly
+   lagging the scroll. */
+const DRAW_SPRING = { stiffness: 140, damping: 32, restDelta: 0.001 } as const;
+
+const VIEW_HEIGHT = 100;
+
+interface ScrollSpineProps {
+  /** Positioning + vertical span, e.g. `absolute inset-y-0 left-0`. */
+  className?: string;
+  /** Hairline weight in CSS px; also the width of the element. */
+  strokeWidth?: number;
+}
+
+/* The SVG stretches to whatever height the caller gives it, so the geometry is
+   a fixed-height box with `preserveAspectRatio="none"` and the element is
+   exactly `strokeWidth` wide — which keeps the x scale at 1:1, so a vertical
+   line's stroke lands on the width it asks for.
+
+   `vector-effect="non-scaling-stroke"` would do the same job for the width, but
+   it moves the whole stroke geometry into screen space while `pathLength`
+   normalises against user units, and the dash pattern the draw is built on then
+   tiles down the line instead of growing. Matching the box to the viewBox is
+   the version that does both. */
+function Frame({
+  children,
+  className,
+  strokeWidth,
+  ref,
+}: {
+  children: React.ReactNode;
+  className: string;
+  strokeWidth: number;
+  ref?: React.Ref<HTMLDivElement>;
+}) {
+  return (
+    <div
+      ref={ref}
+      aria-hidden="true"
+      className={`pointer-events-none ${className}`}
+      style={{ width: `${strokeWidth}px` }}
+    >
+      <svg
+        viewBox={`0 0 ${strokeWidth} ${VIEW_HEIGHT}`}
+        preserveAspectRatio="none"
+        focusable="false"
+        className="block h-full w-full"
+      >
+        {children}
+      </svg>
+    </div>
+  );
+}
+
+function line(strokeWidth: number) {
+  return `M${strokeWidth / 2} 0V${VIEW_HEIGHT}`;
+}
+
+/* Always visible, so the spine has resting-state presence before anything is
+   drawn over it. */
+function Rail({ strokeWidth }: { strokeWidth: number }) {
+  return (
+    <path
+      d={line(strokeWidth)}
+      fill="none"
+      stroke="var(--color-dark)"
+      strokeOpacity={0.15}
+      strokeWidth={strokeWidth}
+    />
+  );
+}
+
+/* The coral hairline draws itself downward as the spine's own box travels
+   through the viewport — it spans its section, so it is its own scroll
+   target. */
+function DrawnSpine({ className, strokeWidth }: Required<ScrollSpineProps>) {
+  const ref = useRef<HTMLDivElement>(null);
+  /* Progress 0 when the spine's top edge is 85% of the way down the viewport,
+     1 when its bottom edge reaches 62% — so the line finishes drawing as the
+     last item settles into reading position, not as the list leaves. */
+  const { scrollYProgress } = useScroll({ target: ref, offset: ['start 85%', 'end 62%'] });
+  const drawn = useSpring(scrollYProgress, DRAW_SPRING);
+
+  return (
+    <Frame ref={ref} className={className} strokeWidth={strokeWidth}>
+      <Rail strokeWidth={strokeWidth} />
+      <motion.path
+        d={line(strokeWidth)}
+        fill="none"
+        stroke="var(--color-coral)"
+        strokeWidth={strokeWidth}
+        style={{ pathLength: drawn }}
+      />
+    </Frame>
+  );
+}
+
+/* Reduced motion gets the finished line and no scroll subscription at all —
+   the branch is above the hooks, so they are never mounted. */
+export default function ScrollSpine({ className = '', strokeWidth = 1 }: ScrollSpineProps) {
+  const reduceMotion = useReducedMotion();
+
+  if (!reduceMotion) {
+    return <DrawnSpine className={className} strokeWidth={strokeWidth} />;
+  }
+
+  return (
+    <Frame className={className} strokeWidth={strokeWidth}>
+      <Rail strokeWidth={strokeWidth} />
+      <path
+        d={line(strokeWidth)}
+        fill="none"
+        stroke="var(--color-coral)"
+        strokeWidth={strokeWidth}
+      />
+    </Frame>
+  );
+}

--- a/components/oferta/CommercialDetails.tsx
+++ b/components/oferta/CommercialDetails.tsx
@@ -2,6 +2,7 @@
 
 import { useLocale, useTranslations } from 'next-intl';
 import ColumnImage from '@/components/ColumnImage';
+import MarqueeEdges from '@/components/MarqueeEdges';
 import RevealHeading from '@/components/RevealHeading';
 import ScrollWeightHeading from './ScrollWeightHeading';
 import StagesTimeline, { type TimelineStage } from './StagesTimeline';
@@ -89,6 +90,7 @@ export default function CommercialDetails() {
               </span>
             ))}
           </div>
+          <MarqueeEdges />
         </div>
         <span className="sr-only">{t('types')}</span>
       </div>

--- a/components/oferta/ProcessSection.tsx
+++ b/components/oferta/ProcessSection.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion';
 import ColumnImage from '@/components/ColumnImage';
+import ScrollSpine from '@/components/ScrollSpine';
 import { useReducedMotion } from '@/hooks/useReducedMotion';
 
 const EASE: [number, number, number, number] = [0.22, 1, 0.36, 1];
@@ -70,20 +71,26 @@ export default function ProcessSection({
           />
 
           <div className="flex flex-col justify-center md:pl-8 lg:pl-12">
-            <ol className="space-y-6 md:space-y-9">
-              {steps.map((step, i) => (
-                <li
-                  key={i}
-                  className="flex items-start gap-3 md:gap-4 leading-[1.4]"
-                  style={{ fontSize: 'clamp(15px, 1.5vw, 20px)' }}
-                >
-                  <span className="text-dark font-[700] tabular-nums">
-                    {String(i + 1).padStart(2, '0')}
-                  </span>
-                  <span className="text-dark font-[400]">{step}</span>
-                </li>
-              ))}
-            </ol>
+            {/* The spine sits on a wrapper rather than the <ol> itself: an
+                ordered list may only contain list items, and the steps keep
+                their own left padding so the numbers clear the line. */}
+            <div className="relative">
+              <ScrollSpine className="absolute inset-y-0 left-0" />
+              <ol className="space-y-6 md:space-y-9 pl-5 md:pl-8">
+                {steps.map((step, i) => (
+                  <li
+                    key={i}
+                    className="flex items-start gap-3 md:gap-4 leading-[1.4]"
+                    style={{ fontSize: 'clamp(15px, 1.5vw, 20px)' }}
+                  >
+                    <span className="text-dark font-[700] tabular-nums">
+                      {String(i + 1).padStart(2, '0')}
+                    </span>
+                    <span className="text-dark font-[400]">{step}</span>
+                  </li>
+                ))}
+              </ol>
+            </div>
           </div>
         </motion.div>
 


### PR DESCRIPTION
Three small motion/visual additions, taken as *techniques* from [skiper-ui](https://skiper-ui.com/components) and reimplemented in our own type, spacing and tokens. No new dependencies, no new colors, no new translation keys. 316 lines of new components, 57 lines of integration.

Context: the whole 107-component catalogue was reviewed. Roughly two-thirds is behind a Pro license (including everything that looked most interesting — Apple Feature Block, Timeline calendar, Projects Showcase, Apple carousel), and most of the free remainder duplicates components we already have (`StagesTimeline`, `Reveal`, `RevealHeading`, `ParallaxImage`, `FaqAccordion`, `ImageStrip`). These three were the ones that added something.

## 1. Progressive blur

A stacked-layer blur primitive (`ProgressiveBlur.tsx`). One `backdrop-filter` can only be uniform, so N layers each take twice the radius of the one below and a shorter mask reach; the radii accumulate into a ramp with no seam. Not the single-layer version upstream ships.

**Nav over hero photos** — `ProjectHero` gets a header band so the coral logo, links and dot hold over whatever photo a page opens with. Mounted at `z-[5]`, just above the fixed photo rather than at header level: at header level it becomes a frosted bar that softens every image scrolling under it, and on a portfolio the photography has to stay crisp.

**Marquee edges** (`MarqueeEdges.tsx`) — the coral marquees were guillotining text mid-letter at both edges; they now dissolve into the beige. Tint only, deliberately: a `backdrop-filter` over text that never stops moving would repaint the whole band every frame, and over flat beige a gradient is indistinguishable from a blur. Applied to all four text marquees — homepage manifesto, studio `<h1>`, oferta commercial, footer.

## 2. Oferta process spine

`ScrollSpine.tsx` — the 01–07 steps get a hairline down the number column: a faint rail visible at rest, with a coral path drawn over it via `pathLength` bound to the section's own scroll progress.

`vector-effect="non-scaling-stroke"` is deliberately **not** used. It keeps the hairline crisp under the stretch, but it moves stroke geometry into screen space while `pathLength` normalises against user units — the dash pattern the draw is built on then tiles down the line instead of growing. Matching the element's width to the viewBox does both.

## 3. Footer dot

`ScrollDot.tsx` — reading progress as the mark the site already uses, on the line it already draws, instead of a new rule laid across the photography. Global, since the hairline is.

It travels `width - 7px` so it sits flush inside both ends, and does that **without measuring anything**: `[data-footer-line]` is the idle drop's landing target and nothing here may read or perturb its layout. A percentage translate resolves against the element's own width, so the travel is handed to a zero-height track that is exactly `calc(100% - 7px)` wide. `FooterHairline` is untouched — its resting render stays pixel-exact and its suite passes unmodified.

## Verification

`pnpm check` passes clean post-rebase — 34 vitest + 44 node tests, typecheck, eslint, i18n parity (384 keys), build 52/52.

Browser-verified at 1440x900 and 390x844 across `/pl`, `/en`, `/pl/studio`, `/pl/oferta`, the three oferta subpages, `/pl/projekty` and a project detail page:
- 0 console errors, no horizontal overflow anywhere
- `[data-footer-line]`'s rect is byte-identical with the dot mounted and with it hidden (`857/0/1440/858`) — the invariant the idle drop depends on
- dot flush at both ends of its travel; spine finishes as step 07 settles; mobile step labels still fit one line
- reduced-motion paths confirmed: `ScrollDot` absent from the DOM, `ScrollSpine` renders fully drawn

## Draft, because

1. **Safari is unverified.** Stacked `backdrop-filter` composites differently there — the ramp may read stronger or weaker. Wants a real-device look.
2. **The idle-drop collision is real.** Measured at 1440: the falling dot spans x 1380–1416, so the two coral dots' footprints overlap for the last ~3% of scroll (coincident at p ~= 0.973). Paint order is correct (nav z-50 over footer z-40) — the 36px dot swallows the 7px one, leaving a small nub below the line. Not a rendering bug, a semantic one. Left as-is by choice; the fix, if wanted, is the dropped dot *becoming* the marker instead of flying home.
3. **No test guards `ScrollDot`.** The `[data-footer-line]` rect invariant is what a future edit is most likely to break, and it is currently only covered by a manual toggle check. `FooterHairline` got a pixel-exact test for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)