### PR TITLE
Make offer dividers full width

### DIFF
--- a/components/oferta/FaqAccordion.tsx
+++ b/components/oferta/FaqAccordion.tsx
@@ -16,13 +16,16 @@ export default function FaqAccordion({ items }: FaqAccordionProps) {
   const [open, setOpen] = useState<number | null>(null);
 
   return (
-    <ul className="border-b border-dark/15">
+    <ul className="relative after:absolute after:left-1/2 after:bottom-0 after:w-dvw after:-translate-x-1/2 after:border-b after:border-dark/15 after:content-['']">
       {items.map((item, i) => {
         const isOpen = open === i;
         const panelId = `faq-panel-${i}`;
         const buttonId = `faq-button-${i}`;
         return (
-          <li key={i} className="border-t border-dark/15">
+          <li
+            key={i}
+            className="relative before:absolute before:left-1/2 before:w-dvw before:-translate-x-1/2 before:border-t before:border-dark/15 before:content-['']"
+          >
             <button
               type="button"
               id={buttonId}

--- a/components/oferta/StagesTimeline.tsx
+++ b/components/oferta/StagesTimeline.tsx
@@ -105,7 +105,10 @@ function DotTrack({
 }) {
   return (
     <div className="relative mt-6 md:mt-10 h-10">
-      <div aria-hidden="true" className="absolute inset-x-0 top-1/2 h-px bg-coral" />
+      <div
+        aria-hidden="true"
+        className="absolute left-1/2 top-1/2 h-px w-dvw -translate-x-1/2 bg-coral"
+      />
       <div className="absolute inset-x-0 top-0 bottom-0 w-[86%] md:w-[72%] mx-auto flex justify-between items-center">
         {stages.map((s, i) => (
           <button

--- a/tests/oferta-full-width-dividers.test.ts
+++ b/tests/oferta-full-width-dividers.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const faqSource = readFileSync(
+  new URL('../components/oferta/FaqAccordion.tsx', import.meta.url),
+  'utf8'
+);
+const timelineSource = readFileSync(
+  new URL('../components/oferta/StagesTimeline.tsx', import.meta.url),
+  'utf8'
+);
+
+test('offer FAQ dividers span the viewport while content stays constrained', () => {
+  assert.match(
+    faqSource,
+    /className="relative before:absolute before:left-1\/2 before:w-dvw before:-translate-x-1\/2/
+  );
+  assert.match(
+    faqSource,
+    /className="relative after:absolute after:left-1\/2 after:bottom-0 after:w-dvw after:-translate-x-1\/2/
+  );
+});
+
+test('offer timeline axis spans the viewport independently of its dots', () => {
+  assert.match(
+    timelineSource,
+    /className="absolute left-1\/2 top-1\/2 h-px w-dvw -translate-x-1\/2 bg-coral"/
+  );
+});


### PR DESCRIPTION
## Summary

- extend FAQ divider lines across the full viewport while keeping accordion content aligned to the content grid
- extend the offer timeline axis across the full viewport while keeping its dots grid-aligned
- add regression coverage for both full-width treatments

## Root cause

Both lines inherited the page's `max-w-[1400px]` content wrapper, so they stopped at the content boundary instead of spanning the page.

## Validation

- `pnpm check`
- visual QA across both locales and every project route
- desktop and mobile viewport-width measurements with no horizontal overflow
